### PR TITLE
Add DesignSystemProvider export

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,3 +26,4 @@ export * from './Tabs';
 export * from './Textarea';
 export * from './ThemeToggle';
 export * from './Tooltip';
+export * from './DesignSystemProvider';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,5 +23,3 @@ export type { DatePickerProps } from './components/DatePicker';
 // Theme Provider
 export { ThemeProvider, useTheme } from './contexts/ThemeContext';
 
-// Design System Provider
-export { DesignSystemProvider } from './components/DesignSystemProvider';


### PR DESCRIPTION
## Summary
- export DesignSystemProvider from component barrel
- remove duplicate export from root index

## Testing
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6843067c70e88325a7e55219543d5ac5