### PR TITLE
Fix export for cn utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.7.2] - 2025-06-06
+
+### Added
+- Re-exported `cn` from `src/utils` so it can be imported from the package root.
+- Updated package version to 1.7.2.
+
 ## [1.7.0] - 2025-05-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k2600x/design-system",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A reusable design system built with React and TypeScript.",
   "author": "k2600x <k2600x@gmail.com>",
   "license": "MIT",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,4 @@
 // Export all utility functions here
-export {};
+// Re-export the `cn` helper so consumers can
+// `import { cn } from '@k2600x/design-system'`
+export { cn } from '../utils';


### PR DESCRIPTION
## Summary
- re-export `cn` from `src/utils`

## Testing
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684306809a5c832582e46b9b555edfd7