### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - run: npm ci
+      - run: npm install
       - run: npm run build --if-present
 
       - name: Verify tag matches package.json version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.7.3] - 2025-06-06
+
+### Fixed
+- Use `npm install` instead of `npm ci` in the publish workflow.
+- Updated package version to 1.7.3.
+
 ## [1.7.2] - 2025-06-06
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k2600x/design-system",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A reusable design system built with React and TypeScript.",
   "author": "k2600x <k2600x@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- use `npm install` in the publish workflow to allow building without a lockfile
- bump version to **1.7.3**
- document patch in CHANGELOG

## Testing
- `npm run build`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68430df8a02c8325ab0e24e9b89a5aeb