### PR TITLE
Fix popover color variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.0] - 2025-06-06
+
+### Fixed
+- Added popover background variables to ensure dropdowns and overlays are opaque
+- Styled MultiSelect dropdown using `bg-popover` colors
+- Updated package version to 1.8.0.
+
 ## [1.7.2] - 2025-06-06
 
 ### Added

--- a/index.css
+++ b/index.css
@@ -1,5 +1,6 @@
 /* Import design tokens (CSS variables) */
 @import "./styles/tokens.css";
+@import "./styles/react-select.css";
 
 @tailwind base;
 @tailwind components;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k2600x/design-system",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "A reusable design system built with React and TypeScript.",
   "author": "k2600x <k2600x@gmail.com>",
   "license": "MIT",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,6 +12,8 @@
   --color-accent-foreground: #111827;
   --color-background-muted: #f3f4f6;
   --color-background-destructive: #fee2e2;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #1a1a1a;
   --color-text: #111827;
   --color-text-muted: #6b7280;
   --color-text-destructive: #b91c1c;
@@ -63,6 +65,8 @@
   --color-border-input: #4b5563;
   --color-border-destructive: #b91c1c;
   --color-focus-ring-offset: #111827;
+  --color-popover: #1e1e1e;
+  --color-popover-foreground: #f5f5f5;
 }
 
 @import "tailwindcss";

--- a/src/styles/react-select.css
+++ b/src/styles/react-select.css
@@ -1,0 +1,28 @@
+.react-select__menu {
+  background-color: var(--color-popover);
+  color: var(--color-popover-foreground);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: 50;
+}
+
+.react-select__option {
+  background-color: var(--color-popover);
+  color: var(--color-popover-foreground);
+}
+
+.react-select__option--is-focused,
+.react-select__option--is-selected {
+  background-color: var(--color-accent);
+  color: var(--color-accent-foreground);
+}
+
+.react-select__multi-value {
+  background-color: var(--color-muted);
+  color: var(--color-text);
+}
+
+.react-select__multi-value__remove {
+  color: var(--color-text-muted);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -13,6 +13,8 @@
   --color-accent-foreground: #111827;
   --color-background-muted: #f3f4f6;
   --color-background-destructive: #fee2e2;
+  --color-popover: #ffffff;
+  --color-popover-foreground: #1a1a1a;
 
   /* Text Colors */
   --color-text: #111827;
@@ -76,6 +78,8 @@
   --color-border: #374151;
   --color-border-input: #4b5563;
   --color-border-destructive: #b91c1c;
-  
+
   --color-focus-ring-offset: #111827;
+  --color-popover: #1e1e1e;
+  --color-popover-foreground: #f5f5f5;
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -30,6 +30,8 @@ export const tokens = {
     background: '#ffffff', // light background
     backgroundMuted: '#f3f4f6', // muted background
     backgroundDestructive: '#fee2e2', // destructive background
+    popover: '#ffffff', // popover background
+    popoverForeground: '#1a1a1a', // popover text
 
     // Text colors
     text: '#111827', // default foreground


### PR DESCRIPTION
## Summary
- add popover color variables to CSS theme files
- expose popover and popoverForeground tokens
- style MultiSelect overlay
- bump package version to 1.8.0

## Testing
- `npm run type-check` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430ff3e7f88325afb0841a57c2d2ff