### PR TITLE
Complete component migration to v2

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,22 +1,136 @@
-import React from 'react';
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../utils';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children?: React.ReactNode;
-  variant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
-  size?: 'default' | 'sm' | 'lg' | 'icon';
+/**
+ * Available button visual variants
+ */
+type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+
+/**
+ * Available button size variants
+ */
+type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
+
+/**
+ * Button variants configuration for class-variance-authority
+ */
+const buttonVariants = cva(
+  cn(
+    'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium',
+    'transition-colors',
+    'disabled:pointer-events-none disabled:opacity-50',
+    '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+    '[&_svg:not([class*="size-"])]:size-4',
+    'outline-none',
+    'focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+    'focus-visible:ring-offset-background',
+    'shrink-0', // Ensure button doesn't shrink in flex containers
+  ),
+  {
+    variants: {
+      variant: {
+        default: cn(
+          'bg-primary',
+          'text-primary-foreground',
+          'hover:bg-primary/90',
+        ),
+        destructive: cn(
+          'bg-destructive',
+          'text-destructive-foreground',
+          'hover:bg-destructive/90',
+        ),
+        outline: cn(
+          'border',
+          'border-border',
+          'bg-background',
+          'text-foreground',
+          'hover:bg-accent hover:text-accent-foreground',
+        ),
+        secondary: cn(
+          'bg-secondary',
+          'text-secondary-foreground',
+          'hover:bg-secondary/90',
+        ),
+        ghost: 'text-foreground hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline focus:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 px-3 text-xs',
+        lg: 'h-11 px-8 text-base',
+        icon: 'h-10 w-10 p-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>,
+    VariantProps<typeof buttonVariants> {
+  /**
+   * Render as a different element type using Radix UI Slot
+   * @default false
+   */
+  asChild?: boolean;
+  /**
+   * Button content
+   */
+  children: React.ReactNode;
+  /**
+   * Visual style variant
+   * @default 'default'
+   */
+  variant?: ButtonVariant;
+  /**
+   * Size variant
+   * @default 'default'
+   */
+  size?: ButtonSize;
+  /**
+   * Additional CSS class name
+   */
+  className?: string;
+  /**
+   * Button type attribute
+   * @default 'button'
+   */
+  type?: 'button' | 'submit' | 'reset';
 }
 
+/**
+ * A customizable button component with multiple variants and sizes.
+ * @component
+ * @example
+ * <Button variant="default" size="default">Click me</Button>
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, variant = 'default', size = 'default', className, ...props }, ref) => {
-    // Basic button, actual styling and variant logic will be added via TDD
+  ({
+    className,
+    variant = 'default',
+    size = 'default',
+    asChild = false,
+    type = 'button',
+    ...props
+  }, ref) => {
+    const Comp = asChild ? Slot : 'button';
     return (
-      <button ref={ref} className={className} {...props}>
-        {children}
-      </button>
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        type={type}
+        {...props}
+      />
     );
   }
 );
 
 Button.displayName = 'Button';
 
-export { Button };
+export { Button, buttonVariants };
+export type { ButtonProps, ButtonVariant, ButtonSize };

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -1,43 +1,31 @@
 // Button component test using Vitest and React Testing Library
+import * as React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Button } from '../Button';
 
 describe('Button component', () => {
-  it('renders with children correctly', () => {
+  it('renders children correctly', () => {
     render(<Button>Click Me</Button>);
-    
-    // Find the button using accessible queries
     const button = screen.getByRole('button', { name: 'Click Me' });
     expect(button).toBeInTheDocument();
-    expect(button.textContent).toBe('Click Me');
   });
 
-  it('passes className prop to the button element', () => {
-    const testClass = 'test-class';
-    render(<Button className={testClass}>Test Button</Button>);
-    
+  it('applies custom className', () => {
+    render(<Button className="test-class">Test</Button>);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass(testClass);
+    expect(button).toHaveClass('test-class');
   });
-  
-  it('forwards additional props to the button element', () => {
+
+  it('forwards props to the button element', () => {
     render(<Button data-testid="test-button">Props Test</Button>);
-    
     const button = screen.getByTestId('test-button');
     expect(button).toBeInTheDocument();
-    expect(button.textContent).toBe('Props Test');
   });
 
-  it('handles variant prop correctly', () => {
-    // Note: This test should be updated when variant implementation is added
-    // Currently the Button component doesn't actually do anything with the variant prop
-    // This is where TDD comes in - first write the test for expected behavior
-    render(<Button variant="secondary">Variant Button</Button>);
-    
-    const button = screen.getByRole('button');
-    expect(button).toBeInTheDocument();
-    // Once implemented, we'd add assertions like:
-    // expect(button).toHaveClass('secondary');
+  it('applies variant classes', () => {
+    const { container } = render(<Button variant="secondary">Variant</Button>);
+    const button = container.firstChild as HTMLElement;
+    expect(button).toHaveClass('bg-secondary');
   });
 });

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,2 +1,2 @@
-// src/components/Button/index.ts
-export * from './Button';
+export { Button, buttonVariants } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,32 +1,257 @@
-import React, { forwardRef } from 'react';
+"use client"
 
-export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
-  options: { value: string; label: string }[];
-  className?: string;
-  label?: string;
-  error?: string;
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "../../utils"
+
+/**
+ * A select component that allows users to select from a list of options.
+ * Based on Radix UI's Select primitive.
+ * 
+ * @component
+ * @example
+ * <Select>
+ *   <SelectTrigger>
+ *     <SelectValue placeholder="Select an option" />
+ *   </SelectTrigger>
+ *   <SelectContent>
+ *     <SelectItem value="option1">Option 1</SelectItem>
+ *     <SelectItem value="option2">Option 2</SelectItem>
+ *   </SelectContent>
+ * </Select>
+ */
+const Select = SelectPrimitive.Root
+
+/**
+ * A component to group select items.
+ */
+const SelectGroup = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Group
+    ref={ref}
+    data-slot="select-group"
+    className={cn(className)}
+    {...props}
+  />
+))
+
+SelectGroup.displayName = "SelectGroup"
+
+/**
+ * The displayed value of the select.
+ */
+const SelectValue = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Value>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Value>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Value
+    ref={ref}
+    data-slot="select-value"
+    className={cn(className)}
+    {...props}
+  />
+))
+
+SelectValue.displayName = "SelectValue"
+
+/**
+ * The button that opens the select popover.
+ */
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    data-slot="select-trigger"
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-border",
+      "bg-background px-3 py-2 text-sm text-foreground ring-offset-background",
+      "placeholder:text-muted-foreground data-[placeholder]:text-muted-foreground",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "aria-invalid:border-destructive aria-invalid:ring-destructive/30",
+      "whitespace-nowrap gap-2",
+      "transition-colors",
+      "[&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground",
+      "*:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDownIcon className="opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+
+SelectTrigger.displayName = "SelectTrigger"
+
+/**
+ * The content of the select, displayed as a popover.
+ */
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      data-slot="select-content"
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border",
+        "bg-popover text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+
+SelectContent.displayName = "SelectContent"
+
+/**
+ * The label for a group of select items.
+ */
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    data-slot="select-label"
+    className={cn("px-2 py-1.5 text-sm font-medium text-foreground", className)}
+    {...props}
+  />
+))
+
+SelectLabel.displayName = "SelectLabel"
+
+/**
+ * An item in the select list.
+ */
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    data-slot="select-item"
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground",
+      "[&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+
+SelectItem.displayName = "SelectItem"
+
+/**
+ * A separator for select items.
+ */
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    data-slot="select-separator"
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+
+SelectSeparator.displayName = "SelectSeparator"
+
+/**
+ * A button for scrolling up in the select list.
+ */
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    data-slot="select-scroll-up-button"
+    className={cn(
+      "flex cursor-default items-center justify-center py-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUpIcon className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+
+SelectScrollUpButton.displayName = "SelectScrollUpButton"
+
+/**
+ * A button for scrolling down in the select list.
+ */
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    data-slot="select-scroll-down-button"
+    className={cn(
+      "flex cursor-default items-center justify-center py-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDownIcon className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+
+SelectScrollDownButton.displayName = "SelectScrollDownButton"
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
 }
-
-export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  ({ options, className = '', label, error, ...props }, ref) => {
-    return (
-      <div className="flex flex-col gap-2">
-        {label && <label className="text-sm font-medium">{label}</label>}
-        <select
-          ref={ref}
-          className={`rounded-md border p-2 ${error ? 'border-red-500' : 'border-gray-300'} ${className}`}
-          {...props}
-        >
-          {options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        {error && <p className="text-xs text-red-500">{error}</p>}
-      </div>
-    );
-  }
-);
-
-Select.displayName = 'Select';

--- a/src/components/Select/__tests__/Select.test.tsx
+++ b/src/components/Select/__tests__/Select.test.tsx
@@ -1,14 +1,25 @@
-import React from 'react';
+import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Select } from '../Select';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '../Select';
 
 describe('Select Component', () => {
-  const options = [{ value: "1", label: "Option 1" }];
-  
   it('renders correctly', () => {
-    render(<Select options={options} data-testid="select" />);
-    expect(screen.getByTestId('select')).toBeInTheDocument();
+    render(
+      <Select>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue placeholder="Select an option" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="1">Option 1</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+    expect(screen.getByTestId('trigger')).toBeInTheDocument();
   });
-  
-  // Add more tests as needed
 });

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,2 +1,13 @@
-export { Select } from './Select';
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from './Select';
 export type { SelectProps } from './Select';


### PR DESCRIPTION
## Summary
- replace old Button with fully migrated variant-based version
- migrate Select to Radix-based variant
- export new APIs from Button and Select
- update accompanying tests

## Testing
- `npm run lint` *(fails: cannot find modules)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684411a7f4ec8325a0b00cc6bbe55555