### PR TITLE
Fix package.json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",   
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "format": "prettier --write .",
     "prepare": "husky"


### PR DESCRIPTION
## Summary
- fix malformed JSON by adding missing comma in `package.json`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68455cc8124c8325ac0d968936700826