### PR TITLE
Fix Storybook preview

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
-import type { Preview } from '@storybook/react';
 import '../src/index.css';
 
-const preview: Preview = {
+/** @type {import('@storybook/react').Preview} */
+const preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' }
   }


### PR DESCRIPTION
## Summary
- convert Storybook preview to JS so Storybook no longer imports a TS file in the browser

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457526b3d8832590e25a8846d512b3