### PR TITLE
Fix Storybook preview loading

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,6 @@
-import '../src/index.css';
+// Use the compiled global styles for Storybook
+// The CSS entry lives at the project root, not under src
+import '../index.css';
 import type { Preview } from '@storybook/react';
 
 const preview: Preview = {

--- a/docs/tasks/completed/TASK-107_storybook-preview-ts-error.md
+++ b/docs/tasks/completed/TASK-107_storybook-preview-ts-error.md
@@ -1,7 +1,7 @@
 # TASK-107: Resolve Storybook preview.ts dynamic import error
 
 ## Status
-pending
+completed
 
 ## Context
 Users report that Storybook fails to load `.storybook/preview.ts` with the error:
@@ -12,11 +12,13 @@ Analysis indicates Storybook is attempting to serve TypeScript directly due to m
 
 ## Plan
 1. Add a dedicated `.storybook/tsconfig.json` extending the project `tsconfig.json` so Storybook can transpile preview files.
-2. Verify Storybook starts without preview loading errors.
+2. Fix incorrect CSS path in `preview.ts` so global styles load correctly.
+3. Verify Storybook starts without preview loading errors by running `npm run build-storybook`.
 
 ## Outcome
 Storybook should load preview successfully and render stories.
 
 ## Implementation Notes
 - Added `.storybook/tsconfig.json` extending the main tsconfig so Storybook can compile preview files.
-- After this change Storybook should no longer attempt to load the TypeScript file directly.
+- Updated `.storybook/preview.ts` to import `../index.css` instead of the non-existent `../src/index.css`.
+- After these changes Storybook builds successfully and renders stories without dynamic import errors.


### PR DESCRIPTION
## Summary
- fix preview CSS import
- mark TASK-107 as completed with details

## Testing
- `npm test`
- `npm run build-storybook`

------
https://chatgpt.com/codex/tasks/task_e_6845abf3e4c08325b597016be605b757