### PR TITLE
Fix missing types and add requirements

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,18 @@
+# Requirements
+
+This design system works with React 17 or newer. The peer dependencies are:
+
+- react >=17.0.0
+- react-dom >=17.0.0
+
+It also depends on the following packages:
+
+- @radix-ui/react-* suite (checkbox, dialog, select, popover, slot, switch, tabs)
+- @tanstack/react-table
+- react-select
+- zustand
+- tailwindcss and tailwindcss-animate
+- class-variance-authority and clsx
+- lucide-react
+
+Ensure these packages are available in your project for full functionality.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 // Main type definition file for the design system
-export * from './dist/types/components';
-export * from './dist/types/index';
+export * from './dist/components';
+export * from './dist/index';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k2600x/design-system",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A reusable design system built with React and TypeScript.",
   "author": "k2600x <k2600x@gmail.com>",
   "license": "MIT",
@@ -19,11 +19,12 @@
   "files": [
     "dist",
     "README.md",
-    "tailwind.preset.js"
+    "tailwind.preset.js",
+    "REQUIREMENTS.md"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && npm run copy-docs",
     "type-check": "tsc --noEmit",
     "clean": "rimraf dist",
     "test": "vitest run",
@@ -35,7 +36,8 @@
     "test-storybook": "node scripts/test-storybook.cjs",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "format": "prettier --write .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "copy-docs": "cp README.md REQUIREMENTS.md dist/"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,
-    "outDir": "dist/types"
+    "outDir": "dist"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.test.tsx", "**/*.test.ts", "**/*.stories.tsx"]


### PR DESCRIPTION
## Summary
- bump version to 2.1.1
- output declarations directly to `dist`
- copy README and REQUIREMENTS into `dist` on build
- ship REQUIREMENTS info alongside package

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68528ade825483258594c878e83e53e5