### PR TITLE
Add requirements file and ship typings

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,27 @@
+# Requirements
+
+This design system is distributed as a library of React components. The package expects the following peer dependencies to be present in your project:
+
+- **react** >= 17.0.0
+- **react-dom** >= 17.0.0
+
+The components themselves make use of several supporting libraries which will be installed automatically when you install this package:
+
+- @radix-ui/react-checkbox
+- @radix-ui/react-dialog
+- @radix-ui/react-popover
+- @radix-ui/react-select
+- @radix-ui/react-slot
+- @radix-ui/react-switch
+- @radix-ui/react-tabs
+- @tanstack/react-table
+- @types/react-select
+- class-variance-authority
+- clsx
+- lucide-react
+- react-select
+- tailwind-merge
+- tailwindcss-animate
+- zustand
+
+Ensure your project uses a version of React compatible with these dependencies (React 17 or newer).  The library's styles also rely on Tailwind CSS v4.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@k2600x/design-system",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A reusable design system built with React and TypeScript.",
   "author": "k2600x <k2600x@gmail.com>",
   "license": "MIT",
@@ -19,11 +19,12 @@
   "files": [
     "dist",
     "README.md",
+    "REQUIREMENTS.md",
     "tailwind.preset.js"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc -p tsconfig.build.json && vite build",
     "type-check": "tsc --noEmit",
     "clean": "rimraf dist",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- generate type declarations during build
- include REQUIREMENTS.md in package files
- document peer dependencies in new REQUIREMENTS.md
- bump version to 2.1.1

## Testing
- `pnpm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68528ade825483258594c878e83e53e5