### PR TITLE
Fix type definitions for build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "types": ["node", "@types/jest", "@types/testing-library__jest-dom"],
+    "types": ["node", "@types/jest", "@testing-library/jest-dom"],
     "lib": ["dom", "esnext"]
   },
   "include": [


### PR DESCRIPTION
## Summary
- update `tsconfig.json` to reference `@testing-library/jest-dom` types

## Testing
- `npm run type-check`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68528e76bf90832597bfc2a0f7f29524