### PR TITLE
feat: add foundational form molecules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ test-types.ts
 tailwind.config.js
 tailwind.preset.js
 generate-docs.js
+storybook-static/

--- a/index.css
+++ b/index.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* Basic Reset */
@@ -76,13 +76,20 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, sans-serif;
   background-color: var(--background);
   color: var(--foreground);
   line-height: 1.5;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin-bottom: 0.5rem;
 }
 
@@ -123,7 +130,9 @@ p {
   margin-bottom: 1rem;
 }
 
-.card-header, .card-content, .card-footer {
+.card-header,
+.card-content,
+.card-footer {
   padding: 0;
 }
 
@@ -140,7 +149,8 @@ p {
   margin-bottom: 1rem;
 }
 
-.table th, .table td {
+.table th,
+.table td {
   border: 1px solid var(--border);
   padding: 0.75rem;
   text-align: left;
@@ -480,7 +490,9 @@ p {
   border-radius: var(--radius);
   cursor: pointer;
   position: relative;
-  transition: background-color 0.2s, border-color 0.2s;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
 }
 
 .checkbox:checked {
@@ -638,7 +650,10 @@ p {
 .datepicker-day {
   cursor: pointer;
   border-radius: 50%;
-  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s,
+    border-color 0.2s;
 }
 
 .datepicker-day:not(.datepicker-day--empty):hover {
@@ -651,7 +666,8 @@ p {
 }
 
 .datepicker-day--today {
-  border: 1px solid var(--primary-semi-transparent, rgba(var(--primary-rgb), 0.5));
+  border: 1px solid
+    var(--primary-semi-transparent, rgba(var(--primary-rgb), 0.5));
   color: var(--primary);
 }
 
@@ -676,7 +692,9 @@ p {
   justify-content: center;
   cursor: pointer;
   background-color: var(--muted-semi-transparent, rgba(var(--muted-rgb), 0.5));
-  transition: border-color 0.2s, background-color 0.2s;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s;
 }
 
 .fileupload-dropzone:hover {
@@ -878,8 +896,6 @@ p {
   align-items: center;
 }
 
-
-
 /* Pagination */
 .pagination-container {
   display: flex;
@@ -895,7 +911,10 @@ p {
   background-color: var(--card);
   color: var(--card-foreground);
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s,
+    border-color 0.2s;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -904,7 +923,9 @@ p {
   font-size: 0.875rem; /* text-sm */
 }
 
-.pagination-button:hover:not(.pagination-button--disabled):not(.pagination-button--active) {
+.pagination-button:hover:not(.pagination-button--disabled):not(
+    .pagination-button--active
+  ) {
   background-color: var(--muted);
 }
 
@@ -938,8 +959,14 @@ p {
 
 /* Popover */
 @keyframes fadeIn {
-  from { opacity: 0; transform: scale(0.95); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .popover-container {
@@ -984,9 +1011,15 @@ p {
 
 /* ProgressBar */
 @keyframes progress-indeterminate {
-  0% { transform: translateX(-100%) scaleX(0.1); }
-  50% { transform: translateX(0) scaleX(0.8); }
-  100% { transform: translateX(100%) scaleX(0.1); }
+  0% {
+    transform: translateX(-100%) scaleX(0.1);
+  }
+  50% {
+    transform: translateX(0) scaleX(0.8);
+  }
+  100% {
+    transform: translateX(100%) scaleX(0.1);
+  }
 }
 
 .progress-bar-container {
@@ -1011,23 +1044,49 @@ p {
 }
 
 /* Sizes */
-.progress-bar-track--sm { height: 0.375rem; /* h-1.5 */ }
-.progress-bar-track--md { height: 0.625rem; /* h-2.5 */ }
-.progress-bar-track--lg { height: 1rem; /* h-4 */ }
+.progress-bar-track--sm {
+  height: 0.375rem; /* h-1.5 */
+}
+.progress-bar-track--md {
+  height: 0.625rem; /* h-2.5 */
+}
+.progress-bar-track--lg {
+  height: 1rem; /* h-4 */
+}
 
 /* Variants - Track */
-.progress-bar-track--primary { background-color: rgba(var(--primary-rgb), 0.2); }
-.progress-bar-track--success { background-color: rgba(var(--success-rgb), 0.2); }
-.progress-bar-track--warning { background-color: rgba(var(--warning-rgb), 0.2); }
-.progress-bar-track--danger { background-color: rgba(var(--destructive-rgb), 0.2); }
-.progress-bar-track--info { background-color: rgba(var(--info-rgb), 0.2); }
+.progress-bar-track--primary {
+  background-color: rgba(var(--primary-rgb), 0.2);
+}
+.progress-bar-track--success {
+  background-color: rgba(var(--success-rgb), 0.2);
+}
+.progress-bar-track--warning {
+  background-color: rgba(var(--warning-rgb), 0.2);
+}
+.progress-bar-track--danger {
+  background-color: rgba(var(--destructive-rgb), 0.2);
+}
+.progress-bar-track--info {
+  background-color: rgba(var(--info-rgb), 0.2);
+}
 
 /* Variants - Indicator */
-.progress-bar-indicator--primary { background-color: var(--primary); }
-.progress-bar-indicator--success { background-color: var(--success); }
-.progress-bar-indicator--warning { background-color: var(--warning); }
-.progress-bar-indicator--danger { background-color: var(--destructive); }
-.progress-bar-indicator--info { background-color: var(--info); }
+.progress-bar-indicator--primary {
+  background-color: var(--primary);
+}
+.progress-bar-indicator--success {
+  background-color: var(--success);
+}
+.progress-bar-indicator--warning {
+  background-color: var(--warning);
+}
+.progress-bar-indicator--danger {
+  background-color: var(--destructive);
+}
+.progress-bar-indicator--info {
+  background-color: var(--info);
+}
 
 /* Indeterminate */
 .progress-bar-indicator--indeterminate {
@@ -1090,7 +1149,9 @@ p {
   height: 1rem;
   border: 2px solid var(--border);
   border-radius: 9999px;
-  transition: border-color 0.2s, background-color 0.2s;
+  transition:
+    border-color 0.2s,
+    background-color 0.2s;
   position: relative;
 }
 
@@ -1293,7 +1354,9 @@ p {
 
 .switch:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--ring);
 }
 
 .switch-thumb {
@@ -1346,7 +1409,9 @@ p {
 
 .tabs-trigger:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--ring);
 }
 
 .tabs-trigger--active {
@@ -1379,7 +1444,9 @@ p {
   padding: 0.5rem 0.75rem; /* 8px 12px */
   font-size: 0.875rem; /* 14px */
   resize: vertical;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
 }
 
 .textarea::placeholder {
@@ -1388,7 +1455,9 @@ p {
 
 .textarea:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--ring);
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--ring);
   border-color: var(--ring);
 }
 
@@ -1397,9 +1466,11 @@ p {
   opacity: 0.5;
 }
 
-.textarea[aria-invalid="true"] {
+.textarea[aria-invalid='true'] {
   border-color: var(--destructive);
-  box-shadow: 0 0 0 2px var(--background), 0 0 0 4px var(--destructive-foreground);
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--destructive-foreground);
 }
 
 /* Tooltip */
@@ -1415,7 +1486,9 @@ p {
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
   box-shadow: var(--shadow-md);
-  transition: opacity 0.2s, transform 0.2s;
+  transition:
+    opacity 0.2s,
+    transform 0.2s;
   opacity: 0;
   transform: scale(0.95);
   pointer-events: none;
@@ -1499,50 +1572,178 @@ p {
   transform: rotate(45deg);
 }
 
-.tooltip-arrow--position-top { bottom: -4px; left: calc(50% - 4px); }
-.tooltip-arrow--position-right { left: -4px; top: calc(50% - 4px); }
-.tooltip-arrow--position-bottom { top: -4px; left: calc(50% - 4px); }
-.tooltip-arrow--position-left { right: -4px; top: calc(50% - 4px); }
+.tooltip-arrow--position-top {
+  bottom: -4px;
+  left: calc(50% - 4px);
+}
+.tooltip-arrow--position-right {
+  left: -4px;
+  top: calc(50% - 4px);
+}
+.tooltip-arrow--position-bottom {
+  top: -4px;
+  left: calc(50% - 4px);
+}
+.tooltip-arrow--position-left {
+  right: -4px;
+  top: calc(50% - 4px);
+}
 
-.tooltip-arrow--variant-default { background-color: var(--popover); border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); }
-.tooltip-arrow--variant-primary { background-color: var(--primary); }
-.tooltip-arrow--variant-success { background-color: var(--success); }
-.tooltip-arrow--variant-warning { background-color: var(--warning); }
-.tooltip-arrow--variant-danger { background-color: var(--destructive); }
+.tooltip-arrow--variant-default {
+  background-color: var(--popover);
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+}
+.tooltip-arrow--variant-primary {
+  background-color: var(--primary);
+}
+.tooltip-arrow--variant-success {
+  background-color: var(--success);
+}
+.tooltip-arrow--variant-warning {
+  background-color: var(--warning);
+}
+.tooltip-arrow--variant-danger {
+  background-color: var(--destructive);
+}
 /* Text */
-.text { font-family: var(--font-family-base); line-height: 1.5; }
-.text--xs { font-size: var(--font-size-xs); }
-.text--sm { font-size: var(--font-size-sm); }
-.text--md { font-size: var(--font-size-md); }
-.text--lg { font-size: var(--font-size-lg); }
-.text--xl { font-size: var(--font-size-xl); }
-.text-weight--normal { font-weight: 400; }
-.text-weight--medium { font-weight: 500; }
-.text-weight--bold { font-weight: 700; }
-.text-align--left { text-align: left; }
-.text-align--center { text-align: center; }
-.text-align--right { text-align: right; }
-.text-align--justify { text-align: justify; }
+.text {
+  font-family: var(--font-family-base);
+  line-height: 1.5;
+}
+.text--xs {
+  font-size: var(--font-size-xs);
+}
+.text--sm {
+  font-size: var(--font-size-sm);
+}
+.text--md {
+  font-size: var(--font-size-md);
+}
+.text--lg {
+  font-size: var(--font-size-lg);
+}
+.text--xl {
+  font-size: var(--font-size-xl);
+}
+.text-weight--normal {
+  font-weight: 400;
+}
+.text-weight--medium {
+  font-weight: 500;
+}
+.text-weight--bold {
+  font-weight: 700;
+}
+.text-align--left {
+  text-align: left;
+}
+.text-align--center {
+  text-align: center;
+}
+.text-align--right {
+  text-align: right;
+}
+.text-align--justify {
+  text-align: justify;
+}
 
 /* Heading */
-.heading { font-family: var(--font-family-base); font-weight: 700; line-height: 1.2; }
-.heading--1 { font-size: var(--heading-size-1); }
-.heading--2 { font-size: var(--heading-size-2); }
-.heading--3 { font-size: var(--heading-size-3); }
-.heading--4 { font-size: var(--heading-size-4); }
-.heading--5 { font-size: var(--heading-size-5); }
-.heading--6 { font-size: var(--heading-size-6); }
+.heading {
+  font-family: var(--font-family-base);
+  font-weight: 700;
+  line-height: 1.2;
+}
+.heading--1 {
+  font-size: var(--heading-size-1);
+}
+.heading--2 {
+  font-size: var(--heading-size-2);
+}
+.heading--3 {
+  font-size: var(--heading-size-3);
+}
+.heading--4 {
+  font-size: var(--heading-size-4);
+}
+.heading--5 {
+  font-size: var(--heading-size-5);
+}
+.heading--6 {
+  font-size: var(--heading-size-6);
+}
 
 /* Label size modifiers */
-.label--sm { font-size: var(--font-size-sm); }
-.label--md { font-size: var(--font-size-md); }
-.label--lg { font-size: var(--font-size-lg); }
+.label--sm {
+  font-size: var(--font-size-sm);
+}
+.label--md {
+  font-size: var(--font-size-md);
+}
+.label--lg {
+  font-size: var(--font-size-lg);
+}
 
 /* Input wrapper */
-.input-wrapper { display: flex; flex-direction: column; }
-.input--error { border-color: var(--destructive); }
-.input-error { color: var(--destructive); font-size: var(--font-size-sm); margin-top: var(--spacing-xs); }
+.input-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+.input--error {
+  border-color: var(--destructive);
+}
+.input-error {
+  color: var(--destructive);
+  font-size: var(--font-size-sm);
+  margin-top: var(--spacing-xs);
+}
 
 /* Spacer */
-.spacer { width: 100%; }
+.spacer {
+  width: 100%;
+}
 
+.input-wrapper--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+.checkbox-field {
+  display: flex;
+  flex-direction: column;
+}
+.checkbox-helper {
+  font-size: var(--font-size-sm);
+  color: var(--muted-foreground);
+  margin-top: var(--spacing-xs);
+}
+.radio-group-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+.radio-group-legend {
+  font-weight: 500;
+  margin-bottom: var(--spacing-xs);
+}
+.field-group {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--spacing-md);
+  display: flex;
+  gap: var(--spacing-md);
+}
+.field-group--column {
+  flex-direction: column;
+}
+.field-group--row {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+.field-group__legend {
+  font-weight: 500;
+  margin-bottom: var(--spacing-sm);
+}

--- a/src/components/CheckboxField/CheckboxField.stories.tsx
+++ b/src/components/CheckboxField/CheckboxField.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { CheckboxField } from './CheckboxField';
+
+const meta: Meta<typeof CheckboxField> = {
+  title: 'Components/CheckboxField',
+  component: CheckboxField,
+  argTypes: {
+    error: { control: 'text' },
+    helperText: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof CheckboxField>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <CheckboxField
+        {...args}
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+      />
+    );
+  },
+  args: { id: 'agree', label: 'I agree', helperText: 'Required to continue' },
+};
+
+export const WithError: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <CheckboxField
+        {...args}
+        checked={checked}
+        onChange={(e) => setChecked(e.target.checked)}
+        error="You must agree"
+      />
+    );
+  },
+  args: { id: 'agree2', label: 'I agree' },
+};

--- a/src/components/CheckboxField/CheckboxField.test.tsx
+++ b/src/components/CheckboxField/CheckboxField.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect, vi } from 'vitest';
+import { CheckboxField } from './CheckboxField';
+
+describe('CheckboxField', () => {
+  it('renders and toggles', async () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CheckboxField id="cb" label="Check" checked={false} onChange={handle} />
+    );
+    const cb = screen.getByLabelText('Check');
+    fireEvent.click(cb);
+    expect(handle).toHaveBeenCalled();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/CheckboxField/CheckboxField.tsx
+++ b/src/components/CheckboxField/CheckboxField.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Label } from '../Label';
+
+export interface CheckboxFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  helperText?: string;
+}
+
+const CheckboxField = React.forwardRef<HTMLInputElement, CheckboxFieldProps>(
+  (
+    { id, label, checked, onChange, error, helperText, className, ...props },
+    ref
+  ) => {
+    const errorId = error ? `${id}-error` : undefined;
+
+    return (
+      <div className={`checkbox-field ${className || ''}`.trim()}>
+        <div className="checkbox-wrapper">
+          <input
+            type="checkbox"
+            id={id}
+            ref={ref}
+            className="checkbox"
+            checked={checked}
+            onChange={onChange}
+            aria-invalid={Boolean(error)}
+            aria-describedby={
+              errorId || (helperText ? `${id}-helper` : undefined)
+            }
+            {...props}
+          />
+          <Label htmlFor={id}>{label}</Label>
+        </div>
+        {helperText && !error && (
+          <p id={`${id}-helper`} className="checkbox-helper">
+            {helperText}
+          </p>
+        )}
+        {error && (
+          <p role="alert" id={errorId} className="input-error">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+CheckboxField.displayName = 'CheckboxField';
+
+export { CheckboxField };

--- a/src/components/CheckboxField/index.ts
+++ b/src/components/CheckboxField/index.ts
@@ -1,0 +1,2 @@
+export { CheckboxField } from './CheckboxField';
+export type { CheckboxFieldProps } from './CheckboxField';

--- a/src/components/ComponentTests.tsx
+++ b/src/components/ComponentTests.tsx
@@ -424,9 +424,9 @@ const ComponentTests = () => {
       <div style={{ display: 'flex', gap: '4rem' }}>
         <div>
           <RadioGroup
-            label="Vertical Group"
+            legend="Vertical Group"
             name="vertical-group"
-            items={[
+            options={[
               { value: 'option1', label: 'Option 1' },
               { value: 'option2', label: 'Option 2' },
               { value: 'option3', label: 'Option 3 (Disabled)', disabled: true },
@@ -437,26 +437,26 @@ const ComponentTests = () => {
         </div>
         <div>
           <RadioGroup
-            label="Horizontal Group"
+            legend="Horizontal Group"
             name="horizontal-group"
-            orientation="horizontal"
-            items={[
+            options={[
               { value: 'option1', label: 'Option 1' },
               { value: 'option2', label: 'Option 2' },
             ]}
-            defaultValue="option1"
+            value={radioValue}
+            onChange={setRadioValue}
           />
         </div>
         <div>
           <RadioGroup
-            label="Disabled Group"
+            legend="Disabled Group"
             name="disabled-group"
-            disabled
-            items={[
+            options={[
               { value: 'option1', label: 'Option 1' },
               { value: 'option2', label: 'Option 2' },
             ]}
-            defaultValue="option1"
+            value={radioValue}
+            onChange={setRadioValue}
           />
         </div>
       </div>

--- a/src/components/FieldGroup/FieldGroup.stories.tsx
+++ b/src/components/FieldGroup/FieldGroup.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { FieldGroup } from './FieldGroup';
+import { InputField } from '../InputField/InputField';
+
+const meta: Meta<typeof FieldGroup> = {
+  title: 'Components/FieldGroup',
+  component: FieldGroup,
+  argTypes: {
+    direction: { control: 'select', options: ['column', 'row'] },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FieldGroup>;
+
+export const Default: Story = {
+  render: (args) => (
+    <FieldGroup {...args} legend="Info">
+      <InputField id="first" label="First" value="" onChange={() => {}} />
+      <InputField id="last" label="Last" value="" onChange={() => {}} />
+    </FieldGroup>
+  ),
+  args: { direction: 'column' },
+};
+
+export const Row: Story = {
+  render: (args) => (
+    <FieldGroup {...args} legend="Row Group" direction="row">
+      <InputField id="a" label="A" value="" onChange={() => {}} />
+      <InputField id="b" label="B" value="" onChange={() => {}} />
+    </FieldGroup>
+  ),
+};

--- a/src/components/FieldGroup/FieldGroup.test.tsx
+++ b/src/components/FieldGroup/FieldGroup.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+import { FieldGroup } from './FieldGroup';
+import { InputField } from '../InputField/InputField';
+
+describe('FieldGroup', () => {
+  it('renders without violations', async () => {
+    const { container } = render(
+      <FieldGroup legend="Test">
+        <InputField id="one" label="One" value="" onChange={() => {}} />
+      </FieldGroup>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/FieldGroup/FieldGroup.tsx
+++ b/src/components/FieldGroup/FieldGroup.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export interface FieldGroupProps
+  extends React.HTMLAttributes<HTMLFieldSetElement> {
+  legend: string;
+  direction?: 'column' | 'row';
+  children: React.ReactNode;
+}
+
+const FieldGroup = ({
+  legend,
+  direction = 'column',
+  children,
+  className,
+  ...props
+}: FieldGroupProps) => {
+  const classes = ['field-group', `field-group--${direction}`, className || '']
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <fieldset className={classes} {...props}>
+      <legend className="field-group__legend">{legend}</legend>
+      {children}
+    </fieldset>
+  );
+};
+
+export { FieldGroup };

--- a/src/components/FieldGroup/index.ts
+++ b/src/components/FieldGroup/index.ts
@@ -1,0 +1,2 @@
+export { FieldGroup } from './FieldGroup';
+export type { FieldGroupProps } from './FieldGroup';

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { InputField } from './InputField';
+
+const meta: Meta<typeof InputField> = {
+  title: 'Components/InputField',
+  component: InputField,
+  argTypes: {
+    layout: { control: 'select', options: ['vertical', 'inline'] },
+    error: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof InputField>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [val, setVal] = useState('');
+    return (
+      <InputField
+        {...args}
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+      />
+    );
+  },
+  args: { id: 'name', label: 'Name', placeholder: 'Jane' },
+};
+
+export const WithError: Story = {
+  render: (args) => {
+    const [val, setVal] = useState('');
+    return (
+      <InputField
+        {...args}
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        error="Required"
+      />
+    );
+  },
+  args: { id: 'email', label: 'Email' },
+};

--- a/src/components/InputField/InputField.test.tsx
+++ b/src/components/InputField/InputField.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect, vi } from 'vitest';
+import { InputField } from './InputField';
+
+describe('InputField', () => {
+  it('renders and handles change', async () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <InputField id="test" label="Test" value="" onChange={handle} />
+    );
+    const input = screen.getByLabelText('Test');
+    fireEvent.change(input, { target: { value: 'a' } });
+    expect(handle).toHaveBeenCalled();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Label } from '../Label';
+
+export interface InputFieldProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'onChange' | 'value'
+  > {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error?: string;
+  layout?: 'vertical' | 'inline';
+}
+
+const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
+  (
+    {
+      id,
+      label,
+      value,
+      onChange,
+      error,
+      disabled,
+      placeholder,
+      layout = 'vertical',
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const wrapperClasses = [
+      'input-wrapper',
+      layout === 'inline' ? 'input-wrapper--inline' : '',
+      className || '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const errorId = error ? `${id}-error` : undefined;
+
+    return (
+      <div className={wrapperClasses}>
+        <Label htmlFor={id}>{label}</Label>
+        <input
+          ref={ref}
+          id={id}
+          className={`input ${error ? 'input--error' : ''}`}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          aria-invalid={Boolean(error)}
+          aria-describedby={errorId}
+          disabled={disabled}
+          {...props}
+        />
+        {error && (
+          <p role="alert" id={errorId} className="input-error">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+InputField.displayName = 'InputField';
+
+export { InputField };

--- a/src/components/InputField/index.ts
+++ b/src/components/InputField/index.ts
@@ -1,0 +1,2 @@
+export { InputField } from './InputField';
+export type { InputFieldProps } from './InputField';

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { RadioGroup } from './RadioGroup';
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  argTypes: {
+    error: { control: 'text' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof RadioGroup>;
+
+const OPTIONS = [
+  { label: 'One', value: '1' },
+  { label: 'Two', value: '2' },
+];
+
+export const Default: Story = {
+  render: (args) => {
+    const [val, setVal] = useState('1');
+    return (
+      <RadioGroup
+        {...args}
+        options={OPTIONS}
+        name="example"
+        legend="Choose"
+        value={val}
+        onChange={setVal}
+      />
+    );
+  },
+};
+
+export const WithError: Story = {
+  render: (args) => {
+    const [val, setVal] = useState('1');
+    return (
+      <RadioGroup
+        {...args}
+        options={OPTIONS}
+        name="err"
+        legend="Pick one"
+        value={val}
+        onChange={setVal}
+        error="Required"
+      />
+    );
+  },
+};

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+import { RadioGroup } from './RadioGroup';
+
+const OPTIONS = [
+  { label: 'One', value: '1' },
+  { label: 'Two', value: '2' },
+];
+
+describe('RadioGroup', () => {
+  it('changes selection', async () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <RadioGroup
+        options={OPTIONS}
+        name="grp"
+        legend="Pick"
+        value="1"
+        onChange={handle}
+      />
+    );
+    fireEvent.click(screen.getByLabelText('Two'));
+    expect(handle).toHaveBeenCalledWith('2');
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,78 +1,63 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { Label } from '../Label';
 
-export interface RadioGroupItem {
-  value: string;
+export interface RadioOption {
   label: string;
+  value: string;
   disabled?: boolean;
 }
 
-export interface RadioGroupProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
-  items: RadioGroupItem[];
-  value?: string;
-  defaultValue?: string;
-  onChange?: (value: string) => void;
-  name?: string;
-  disabled?: boolean;
-  orientation?: 'vertical' | 'horizontal';
-  label?: string;
+export interface RadioGroupProps
+  extends Omit<React.HTMLAttributes<HTMLFieldSetElement>, 'onChange'> {
+  name: string;
+  options: RadioOption[];
+  value: string;
+  onChange: (value: string) => void;
+  legend: string;
+  error?: string;
 }
 
 const RadioGroup = ({
-  items,
-  value: valueProp,
-  defaultValue,
+  name,
+  options,
+  value,
   onChange,
-  name = 'radio-group',
-  disabled = false,
-  orientation = 'vertical',
-  label,
+  legend,
+  error,
   className,
   ...props
 }: RadioGroupProps) => {
-  const [internalValue, setInternalValue] = useState(defaultValue);
-  const isControlled = valueProp !== undefined;
-  const currentValue = isControlled ? valueProp : internalValue;
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    if (!isControlled) {
-      setInternalValue(newValue);
-    }
-    onChange?.(newValue);
-  };
-
-  const containerClasses = [
-    'radio-group',
-    `radio-group--${orientation}`,
-    disabled ? 'radio-group--disabled' : '',
-    className || ''
-  ].filter(Boolean).join(' ');
-
+  const errorId = error ? `${name}-error` : undefined;
   return (
-    <div className={containerClasses} role="radiogroup" aria-label={label} {...props}>
-      {label && <span className="radio-group__label">{label}</span>}
-      <div className="radio-group__items-container">
-        {items.map((item) => (
-          <label
-            key={item.value}
-            className={`radio-item ${item.disabled || disabled ? 'radio-item--disabled' : ''}`}>
+    <fieldset className={`radio-group-fieldset ${className || ''}`} {...props}>
+      <legend className="radio-group-legend">{legend}</legend>
+      {options.map((opt) => {
+        const id = `${name}-${opt.value}`;
+        return (
+          <label key={opt.value} className="radio-item">
             <input
               type="radio"
+              id={id}
               name={name}
-              value={item.value}
-              checked={currentValue === item.value}
-              onChange={handleChange}
-              disabled={disabled || item.disabled}
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={(e) => onChange(e.target.value)}
+              disabled={opt.disabled}
               className="radio-item__input"
+              aria-invalid={Boolean(error)}
+              aria-describedby={errorId}
             />
-            <span className="radio-item__label">{item.label}</span>
+            <Label htmlFor={id}>{opt.label}</Label>
           </label>
-        ))}
-      </div>
-    </div>
+        );
+      })}
+      {error && (
+        <p role="alert" id={errorId} className="input-error">
+          {error}
+        </p>
+      )}
+    </fieldset>
   );
 };
-
-RadioGroup.displayName = 'RadioGroup';
 
 export { RadioGroup };

--- a/src/components/RadioGroup/index.ts
+++ b/src/components/RadioGroup/index.ts
@@ -1,2 +1,2 @@
 export { RadioGroup } from './RadioGroup';
-export type { RadioGroupProps, RadioGroupItem } from './RadioGroup';
+export type { RadioGroupProps, RadioOption } from './RadioGroup';

--- a/src/components/TextAreaField/TextAreaField.stories.tsx
+++ b/src/components/TextAreaField/TextAreaField.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { TextAreaField } from './TextAreaField';
+
+const meta: Meta<typeof TextAreaField> = {
+  title: 'Components/TextAreaField',
+  component: TextAreaField,
+  argTypes: {
+    layout: { control: 'select', options: ['vertical', 'inline'] },
+    error: { control: 'text' },
+    autoGrow: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TextAreaField>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [val, setVal] = useState('');
+    return (
+      <TextAreaField
+        {...args}
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+      />
+    );
+  },
+  args: { id: 'bio', label: 'Bio', placeholder: 'Tell us about you' },
+};
+
+export const AutoGrow: Story = {
+  render: (args) => {
+    const [val, setVal] = useState('');
+    return (
+      <TextAreaField
+        {...args}
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        autoGrow
+      />
+    );
+  },
+  args: { id: 'notes', label: 'Notes' },
+};

--- a/src/components/TextAreaField/TextAreaField.test.tsx
+++ b/src/components/TextAreaField/TextAreaField.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect, vi } from 'vitest';
+import { TextAreaField } from './TextAreaField';
+
+describe('TextAreaField', () => {
+  it('renders and handles change', async () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <TextAreaField id="bio" label="Bio" value="" onChange={handle} />
+    );
+    const textarea = screen.getByLabelText('Bio');
+    fireEvent.change(textarea, { target: { value: 'a' } });
+    expect(handle).toHaveBeenCalled();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/TextAreaField/TextAreaField.tsx
+++ b/src/components/TextAreaField/TextAreaField.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useRef } from 'react';
+import { Label } from '../Label';
+
+export interface TextAreaFieldProps
+  extends Omit<
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    'onChange' | 'value'
+  > {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  error?: string;
+  autoGrow?: boolean;
+  layout?: 'vertical' | 'inline';
+}
+
+const TextAreaField = React.forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(
+  (
+    {
+      id,
+      label,
+      value,
+      onChange,
+      error,
+      autoGrow,
+      layout = 'vertical',
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const internalRef = useRef<HTMLTextAreaElement | null>(null);
+    const combinedRef = (node: HTMLTextAreaElement) => {
+      internalRef.current = node;
+      if (typeof ref === 'function') ref(node);
+      else if (ref)
+        (ref as React.MutableRefObject<HTMLTextAreaElement | null>).current =
+          node;
+    };
+
+    useEffect(() => {
+      if (autoGrow && internalRef.current) {
+        internalRef.current.style.height = 'auto';
+        internalRef.current.style.height = `${internalRef.current.scrollHeight}px`;
+      }
+    }, [value, autoGrow]);
+
+    const wrapperClasses = [
+      'input-wrapper',
+      layout === 'inline' ? 'input-wrapper--inline' : '',
+      className || '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    const errorId = error ? `${id}-error` : undefined;
+
+    return (
+      <div className={wrapperClasses}>
+        <Label htmlFor={id}>{label}</Label>
+        <textarea
+          ref={combinedRef}
+          id={id}
+          className={`textarea ${error ? 'textarea--error' : ''}`}
+          value={value}
+          onChange={onChange}
+          aria-invalid={Boolean(error)}
+          aria-describedby={errorId}
+          {...props}
+        />
+        {error && (
+          <p role="alert" id={errorId} className="input-error">
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  }
+);
+
+TextAreaField.displayName = 'TextAreaField';
+
+export { TextAreaField };

--- a/src/components/TextAreaField/index.ts
+++ b/src/components/TextAreaField/index.ts
@@ -1,0 +1,2 @@
+export { TextAreaField } from './TextAreaField';
+export type { TextAreaFieldProps } from './TextAreaField';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -28,6 +28,8 @@ export * from './Switch/index';
 export * from './Table/Table';
 export * from './Tabs/index';
 export * from './Textarea/index';
-export * from './Tooltip/index'
-
-
+export * from './Tooltip/index';
+export * from './InputField';
+export * from './TextAreaField';
+export * from './CheckboxField';
+export * from './FieldGroup';


### PR DESCRIPTION
### ✨ Resumen del cambio
Se agregan los componentes de moléculas para formularios: `InputField`, `TextAreaField`, `CheckboxField`, `RadioGroup` renovado y `FieldGroup`. Incluyen ejemplos en Storybook, pruebas con RTL y jest-axe y estilos básicos.

### ✅ Checklist de entrega
- [x] Componentes funcionan correctamente
- [x] Tests incluidos y pasan (`pnpm test`)
- [x] Documentación en Storybook
- [x] Accesibilidad validada (`jest-axe`)
- [x] Sin errores de lint ni tipo (`pnpm lint`)
- [x] Preview de Storybook actualizado


------
https://chatgpt.com/codex/tasks/task_e_6854505280d083259558de2bc9586179