### PR TITLE
Add Storybook coverage check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  storybook-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Storybook
+        run: pnpm run storybook:build
+
+      - name: Check Storybook coverage
+        run: pnpm run check:storybook

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "storybook": "storybook dev",
+    "storybook:build": "storybook build",
     "build-storybook": "storybook build",
     "test-storybook": "node scripts/test-storybook.cjs",
+    "check:storybook": "node scripts/check-storybook.cjs",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "format": "prettier --write .",
     "prepare": "husky"

--- a/scripts/check-storybook.cjs
+++ b/scripts/check-storybook.cjs
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const componentsDir = path.join(__dirname, '..', 'src', 'components');
+
+function getComponentDirs() {
+  return fs
+    .readdirSync(componentsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+}
+
+function findStories(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.stories.tsx') || f.endsWith('.stories.mdx'));
+}
+
+function checkStorybookFiles() {
+  const missing = [];
+  const empty = [];
+
+  for (const component of getComponentDirs()) {
+    const componentDir = path.join(componentsDir, component);
+    const stories = findStories(componentDir);
+    if (stories.length === 0) {
+      missing.push(component);
+      continue;
+    }
+    for (const file of stories) {
+      const filePath = path.join(componentDir, file);
+      const { size } = fs.statSync(filePath);
+      if (size === 0) {
+        empty.push(filePath);
+      }
+    }
+  }
+
+  return { missing, empty };
+}
+
+function getChangedComponents(baseRef = 'origin/main') {
+  let diff = '';
+  try {
+    // Only attempt diff if repository has the base ref
+    execSync(`git rev-parse --verify ${baseRef}`, { stdio: 'ignore' });
+    diff = execSync(`git diff --name-only ${baseRef}...HEAD`, {
+      encoding: 'utf8',
+    });
+  } catch (e) {
+    return [];
+  }
+  const changedFiles = diff.split(/\n/).filter(Boolean);
+  const components = new Set();
+  changedFiles.forEach((file) => {
+    if (file.startsWith('src/components/')) {
+      const parts = file.split('/');
+      if (parts.length >= 3) {
+        const component = parts[2];
+        if (!file.includes('.stories.')) {
+          components.add(component);
+        }
+      }
+    }
+  });
+  const changedStories = new Set();
+  changedFiles.forEach((file) => {
+    if (file.startsWith('src/components/')) {
+      const parts = file.split('/');
+      if (parts.length >= 3 && file.includes('.stories.')) {
+        changedStories.add(parts[2]);
+      }
+    }
+  });
+
+  const missingStoryChange = [];
+  components.forEach((comp) => {
+    if (!changedStories.has(comp)) {
+      missingStoryChange.push(comp);
+    }
+  });
+
+  return missingStoryChange;
+}
+
+function main() {
+  const { missing, empty } = checkStorybookFiles();
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : 'origin/main';
+  const diffIssues = getChangedComponents(baseRef);
+
+  let hasError = false;
+
+  if (missing.length) {
+    console.error('Components missing stories:', missing.join(', '));
+    hasError = true;
+  }
+  if (empty.length) {
+    console.error('Story files are empty:', empty.join(', '));
+    hasError = true;
+  }
+  if (diffIssues.length) {
+    console.error('Components changed without story updates:', diffIssues.join(', '));
+    hasError = true;
+  }
+
+  if (hasError) {
+    process.exit(1);
+  } else {
+    console.log('Storybook check passed');
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `check-storybook.cjs` script to verify stories exist and changed components update their stories
- expose new scripts in `package.json`
- add CI workflow to build and validate Storybook

## Testing
- `pnpm test`
- `pnpm run storybook:build`
- `pnpm run check:storybook` *(fails: Components missing stories)*

------
https://chatgpt.com/codex/tasks/task_e_68546b9a839c8325a7d21de223b7519a