### PR TITLE
feat: add DataTable component

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+void React;
+import { DataTable, ColumnDef } from './DataTable';
+import { TableToolbar } from '../TableToolbar';
+import { Button } from '../Button/Button';
+
+interface Row {
+  id: number;
+  name: string;
+  age: number;
+}
+
+const columns: ColumnDef<Row>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+  },
+  {
+    accessorKey: 'age',
+    header: 'Age',
+  },
+];
+
+const data: Row[] = [
+  { id: 1, name: 'Alice', age: 30 },
+  { id: 2, name: 'Bob', age: 25 },
+];
+
+const meta: Meta<typeof DataTable<Row>> = {
+  title: 'Components/DataTable',
+  component: DataTable,
+  args: { columns, data },
+};
+export default meta;
+
+type Story = StoryObj<typeof DataTable<Row>>;
+
+export const Basic: Story = {};
+
+export const Loading: Story = {
+  args: { isLoading: true },
+};
+
+export const Empty: Story = {
+  args: { data: [] },
+};
+
+export const WithToolbar: Story = {
+  render: args => (
+    <div>
+      <TableToolbar actions={<Button>New</Button>} onSearch={() => {}} count={2} />
+      <DataTable {...args} />
+    </div>
+  ),
+};

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  getSortedRowModel,
+} from '@tanstack/react-table';
+import { EmptyState } from '../EmptyState';
+import { Loader } from '../Loader';
+import { Pagination } from '../Pagination';
+
+export interface DataTableProps<T extends { id: React.Key }> {
+  columns: ColumnDef<T, unknown>[];
+  data: T[];
+  isLoading?: boolean;
+  emptyLabel?: string;
+  onRowClick?: (row: T) => void;
+  onRowSelect?: (rows: T[]) => void;
+  rowActions?: (row: T) => React.ReactNode;
+  pagination?: boolean;
+  sortable?: boolean;
+  selectable?: boolean;
+  striped?: boolean;
+  hover?: boolean;
+  className?: string;
+}
+
+export function DataTable<T extends { id: React.Key }>({
+  columns,
+  data,
+  isLoading,
+  emptyLabel = 'No data',
+  onRowClick,
+  onRowSelect,
+  rowActions,
+  pagination,
+  sortable,
+  selectable,
+  striped,
+  hover,
+  className,
+}: DataTableProps<T>) {
+  const [rowSelection, setRowSelection] = React.useState({});
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      rowSelection,
+    },
+    enableSorting: sortable,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  React.useEffect(() => {
+    if (onRowSelect) {
+      const rows = table
+        .getSelectedRowModel()
+        .flatRows.map(r => r.original);
+      onRowSelect(rows);
+    }
+  }, [rowSelection]);
+
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <tr>
+          <td colSpan={columns.length + (selectable ? 1 : 0)}>
+            <Loader />
+          </td>
+        </tr>
+      );
+    }
+
+    if (!data.length) {
+      return (
+        <tr>
+          <td colSpan={columns.length + (selectable ? 1 : 0)}>
+            <EmptyState title={emptyLabel} />
+          </td>
+        </tr>
+      );
+    }
+
+    return table.getRowModel().rows.map(row => (
+      <tr
+        key={row.id}
+        onClick={() => onRowClick?.(row.original)}
+        className={
+          `${hover ? 'table-row-hover' : ''} ` +
+          `${striped ? (row.index % 2 === 0 ? 'table-row-striped' : '') : ''}`
+        }
+      >
+        {selectable && (
+          <td>
+            <input
+              type="checkbox"
+              checked={row.getIsSelected()}
+              onChange={row.getToggleSelectedHandler()}
+            />
+          </td>
+        )}
+        {row.getVisibleCells().map(cell => (
+          <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+        ))}
+        {rowActions && <td>{rowActions(row.original)}</td>}
+      </tr>
+    ));
+  };
+
+  return (
+    <div className={`data-table ${className || ''}`}>
+      <table className="table">
+        <thead>
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {selectable && <th></th>}
+              {headerGroup.headers.map(header => (
+                <th
+                  key={header.id}
+                  onClick={header.column.getToggleSortingHandler()}
+                  aria-sort={header.column.getIsSorted() ? (header.column.getIsSorted() === 'asc' ? 'ascending' : 'descending') : 'none'}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  {sortable && header.column.getIsSorted() === 'asc' && ' ▲'}
+                  {sortable && header.column.getIsSorted() === 'desc' && ' ▼'}
+                </th>
+              ))}
+              {rowActions && <th></th>}
+            </tr>
+          ))}
+        </thead>
+        <tbody>{renderBody()}</tbody>
+      </table>
+      {pagination && (
+        <Pagination
+          totalItems={data.length}
+          itemsPerPage={10}
+          currentPage={1}
+          onPageChange={() => {}}
+        />
+      )}
+    </div>
+  );
+}
+
+export type { ColumnDef } from '@tanstack/react-table';

--- a/src/components/DataTable/index.ts
+++ b/src/components/DataTable/index.ts
@@ -1,0 +1,2 @@
+export { DataTable } from './DataTable';
+export type { DataTableProps, ColumnDef } from './DataTable';

--- a/src/components/TableToolbar/TableToolbar.tsx
+++ b/src/components/TableToolbar/TableToolbar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export interface TableToolbarProps extends React.HTMLAttributes<HTMLDivElement> {
+  onSearch?: (value: string) => void;
+  actions?: React.ReactNode;
+  count?: number;
+}
+
+export const TableToolbar = React.forwardRef<HTMLDivElement, TableToolbarProps>(
+  ({ onSearch, actions, count, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={`table-toolbar flex items-center justify-between mb-[var(--spacing-sm)] ${className || ''}`}
+        {...props}
+      >
+        <div className="flex items-center gap-[var(--spacing-sm)]">
+          {onSearch && (
+            <input
+              type="text"
+              aria-label="Search"
+              onChange={e => onSearch(e.target.value)}
+              className="input"
+            />
+          )}
+          {typeof count === 'number' && (
+            <span className="text-sm text-gray-500">{count} items</span>
+          )}
+        </div>
+        <div className="flex items-center gap-[var(--spacing-sm)]">{actions}</div>
+      </div>
+    );
+  }
+);
+
+TableToolbar.displayName = 'TableToolbar';

--- a/src/components/TableToolbar/index.ts
+++ b/src/components/TableToolbar/index.ts
@@ -1,0 +1,2 @@
+export { TableToolbar } from './TableToolbar';
+export type { TableToolbarProps } from './TableToolbar';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -44,3 +44,5 @@ export * from './Stack';
 export * from './Navbar';
 export * from './Sidebar';
 export * from './Menu';
+export * from './DataTable';
+export * from './TableToolbar';


### PR DESCRIPTION
## Summary
- implement DataTable with loading and empty states
- add TableToolbar component for actions and search
- provide Storybook stories for DataTable
- export new components in index

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855701ef0bc8325955ac966aa963220