### PR TITLE
feat: use Tailwind styles for data table components

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useState } from 'react';
+import { DataTable } from './DataTable';
+import type { DataTablePagination } from './DataTable';
+import { TableToolbar } from './TableToolbar';
+import { Button } from '../Button/Button';
+
+interface Row {
+  id: number;
+  name: string;
+  age: number;
+}
+
+const columns = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'age', header: 'Age' },
+] as const;
+
+const data: Row[] = [
+  { id: 1, name: 'Alice', age: 30 },
+  { id: 2, name: 'Bob', age: 25 },
+  { id: 3, name: 'Charlie', age: 28 },
+];
+
+const meta: Meta<typeof DataTable<Row>> = {
+  title: 'Components/DataTable',
+  component: DataTable,
+  args: {
+    columns,
+    data,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof DataTable<Row>>;
+
+export const WithData: Story = {};
+
+export const Empty: Story = {
+  args: { data: [] },
+};
+
+export const Loading: Story = {
+  args: { isLoading: true },
+};
+
+export const WithPaginationAndSelection: Story = {
+  render: (args) => {
+    const [page, setPage] = useState(1);
+    const pagination: DataTablePagination = {
+      pageCount: 3,
+      currentPage: page,
+      itemsPerPage: 3,
+      onPageChange: setPage,
+    };
+    return (
+      <div>
+        <TableToolbar actions={<Button>New</Button>} count={data.length} />
+        <DataTable
+          {...args}
+          selectable
+          rowActions={(row) => <Button size="sm">Edit {row.name}</Button>}
+          pagination={pagination}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+import { DataTable } from './DataTable';
+
+interface Row {
+  id: number;
+  name: string;
+}
+
+const columns = [{ accessorKey: 'name', header: 'Name' }] as const;
+
+const data: Row[] = [{ id: 1, name: 'Alice' }];
+
+describe('DataTable', () => {
+  it('renders without accessibility violations', async () => {
+    const { container } = render(<DataTable columns={columns} data={data} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  SortingState,
+  getSortedRowModel,
+  RowSelectionState,
+} from '@tanstack/react-table';
+import { EmptyState } from '../EmptyState';
+import { Pagination } from '../Pagination';
+import { SkeletonRow } from './SkeletonRow';
+
+export interface DataTablePagination {
+  pageCount: number;
+  currentPage: number;
+  itemsPerPage: number;
+  onPageChange: (page: number) => void;
+}
+
+export interface DataTableProps<TData extends { id: React.Key }> {
+  columns: ColumnDef<TData, unknown>[];
+  data: TData[];
+  isLoading?: boolean;
+  emptyLabel?: string;
+  onRowClick?: (row: TData) => void;
+  onRowSelect?: (rows: TData[]) => void;
+  rowActions?: (row: TData) => React.ReactNode;
+  pagination?: DataTablePagination;
+  sortable?: boolean;
+  selectable?: boolean;
+  striped?: boolean;
+  hover?: boolean;
+  className?: string;
+}
+
+export function DataTable<TData extends { id: React.Key }>({
+  columns,
+  data,
+  isLoading,
+  emptyLabel = 'No data',
+  onRowClick,
+  onRowSelect,
+  rowActions,
+  pagination,
+  sortable = true,
+  selectable = false,
+  striped = false,
+  hover = false,
+  className,
+}: DataTableProps<TData>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({});
+
+  const tableColumns = React.useMemo<ColumnDef<TData, unknown>[]>(() => {
+    let cols = [...columns];
+    if (selectable) {
+      cols = [
+        {
+          id: '__select',
+          header: ({ table }) => (
+            <input
+              type="checkbox"
+              checked={table.getIsAllRowsSelected()}
+              onChange={table.getToggleAllRowsSelectedHandler()}
+              aria-label="Select all rows"
+            />
+          ),
+          cell: ({ row }) => (
+            <input
+              type="checkbox"
+              checked={row.getIsSelected()}
+              disabled={!row.getCanSelect()}
+              onChange={row.getToggleSelectedHandler()}
+              aria-label="Select row"
+            />
+          ),
+        },
+        ...cols,
+      ];
+    }
+    if (rowActions) {
+      cols = [
+        ...cols,
+        {
+          id: '__actions',
+          header: '',
+          cell: ({ row }) => rowActions(row.original),
+        },
+      ];
+    }
+    return cols;
+  }, [columns, rowActions, selectable]);
+
+  const table = useReactTable({
+    data,
+    columns: tableColumns,
+    state: { sorting, rowSelection },
+    onSortingChange: setSorting,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: sortable ? getSortedRowModel() : undefined,
+    enableSorting: sortable,
+  });
+
+  React.useEffect(() => {
+    if (onRowSelect) {
+      const selected = table.getSelectedRowModel().rows.map((r) => r.original);
+      onRowSelect(selected);
+    }
+  }, [onRowSelect, rowSelection, table]);
+
+  const headers = table.getHeaderGroups();
+  const rows = table.getRowModel().rows;
+  const colLength = table.getVisibleLeafColumns().length;
+
+  return (
+    <div className={clsx('overflow-x-auto', className)}>
+      <table className="w-full border-collapse mb-4">
+        <thead>
+          {headers.map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                const isSorted = header.column.getIsSorted();
+                return (
+                  <th
+                    key={header.id}
+                    onClick={header.column.getToggleSortingHandler()}
+                    aria-sort={
+                      isSorted
+                        ? isSorted === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : 'none'
+                    }
+                    className={clsx(
+                      'border border-[var(--border)] bg-[var(--secondary)] px-[var(--spacing-md)] py-[var(--spacing-sm)] text-left',
+                      sortable && header.column.getCanSort() && 'cursor-pointer select-none'
+                    )}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </th>
+                );
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {isLoading ? (
+            [...Array(3)].map((_, i) => (
+              <SkeletonRow key={i} columns={colLength} />
+            ))
+          ) : rows.length === 0 ? (
+            <tr>
+              <td colSpan={colLength}>
+                <EmptyState title={emptyLabel} />
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr
+                key={row.id}
+                onClick={() => onRowClick?.(row.original)}
+                className={clsx(
+                  onRowClick && 'cursor-pointer',
+                  striped && 'even:bg-[var(--muted)]',
+                  hover && 'hover:bg-[var(--accent)]'
+                )}
+                aria-rowindex={row.index + 1}
+                aria-selected={row.getIsSelected() || undefined}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td
+                    key={cell.id}
+                    className="border border-[var(--border)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+      {pagination && (
+        <div className="mt-2">
+          <Pagination
+            totalItems={pagination.pageCount * pagination.itemsPerPage}
+            itemsPerPage={pagination.itemsPerPage}
+            currentPage={pagination.currentPage}
+            onPageChange={pagination.onPageChange}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+DataTable.displayName = 'DataTable';

--- a/src/components/DataTable/SkeletonRow.tsx
+++ b/src/components/DataTable/SkeletonRow.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Skeleton } from '../Skeleton';
+
+export interface SkeletonRowProps {
+  columns: number;
+}
+
+export const SkeletonRow = ({ columns }: SkeletonRowProps) => (
+  <tr>
+    {Array.from({ length: columns }).map((_, i) => (
+      <td
+        key={i}
+        className="border border-[var(--border)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
+      >
+        <Skeleton height="1rem" className="w-full" />
+      </td>
+    ))}
+  </tr>
+);

--- a/src/components/DataTable/TableToolbar.stories.tsx
+++ b/src/components/DataTable/TableToolbar.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { TableToolbar } from './TableToolbar';
+import { Button } from '../Button/Button';
+
+const meta: Meta<typeof TableToolbar> = {
+  title: 'Components/TableToolbar',
+  component: TableToolbar,
+  argTypes: {
+    onSearch: { action: 'search' },
+  },
+  args: {
+    count: 3,
+    actions: <Button>New</Button>,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof TableToolbar>;
+
+export const Default: Story = {};
+
+export const WithSearch: Story = {
+  args: { onSearch: () => {} },
+};

--- a/src/components/DataTable/TableToolbar.tsx
+++ b/src/components/DataTable/TableToolbar.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+
+export interface TableToolbarProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  onSearch?: (term: string) => void;
+  actions?: React.ReactNode;
+  count?: number;
+}
+
+export const TableToolbar = React.forwardRef<HTMLDivElement, TableToolbarProps>(
+  ({ onSearch, actions, count, className, ...props }, ref) => {
+    const [value, setValue] = useState('');
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value;
+      setValue(val);
+      onSearch?.(val);
+    };
+    return (
+      <div
+        ref={ref}
+        className={clsx('mb-2 flex items-center gap-2', className)}
+        {...props}
+      >
+        {onSearch && (
+          <input
+            type="search"
+            value={value}
+            onChange={handleChange}
+            className="input"
+            placeholder="Search..."
+          />
+        )}
+        <div className="flex-1" />
+        {count !== undefined && (
+          <span className="text-sm text-muted-foreground">{count}</span>
+        )}
+        {actions}
+      </div>
+    );
+  }
+);
+
+TableToolbar.displayName = 'TableToolbar';

--- a/src/components/DataTable/index.ts
+++ b/src/components/DataTable/index.ts
@@ -1,0 +1,3 @@
+export { DataTable } from './DataTable';
+export type { DataTableProps, DataTablePagination } from './DataTable';
+export { TableToolbar } from './TableToolbar';

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Skeleton } from './Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  args: { width: '100%', height: '1rem' },
+};
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {};

--- a/src/components/Skeleton/Skeleton.test.tsx
+++ b/src/components/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders without accessibility violations', async () => {
+    const { container } = render(<Skeleton width="100%" height="1rem" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  width?: string | number;
+  height?: string | number;
+}
+
+/** A basic skeleton placeholder for loading states. */
+export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ width, height, style, className, ...props }, ref) => {
+    const inlineStyle = { width, height, ...style } as React.CSSProperties;
+    return (
+      <div
+        ref={ref}
+        className={clsx(
+          'animate-pulse rounded-[var(--radius)] bg-[var(--muted)]',
+          className,
+        )}
+        style={inlineStyle}
+        aria-hidden="true"
+        {...props}
+      />
+    );
+  }
+);
+Skeleton.displayName = 'Skeleton';

--- a/src/components/Skeleton/index.ts
+++ b/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -44,3 +44,5 @@ export * from './Stack';
 export * from './Navbar';
 export * from './Sidebar';
 export * from './Menu';
+export * from './DataTable';
+export * from './Skeleton';


### PR DESCRIPTION
## Summary
- refactor `DataTable` to rely on Tailwind utility classes
- adapt `TableToolbar`, `SkeletonRow` and `Skeleton` to match Tailwind usage
- remove custom CSS for table features

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm run check:storybook`


------
https://chatgpt.com/codex/tasks/task_e_6855701ef0bc8325955ac966aa963220