### PR TITLE
Add Storybook docs and theme toolbar

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
-  stories: ['../src/components/**/*.stories.@(ts|tsx|mdx)'],
+  stories: ['../src/components/**/*.stories.@(ts|tsx|mdx)', '../src/docs/**/*.stories.@(mdx|tsx)'],
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,27 +1,47 @@
 // Import Tailwind CSS with design system styles
 import './tailwind.css';
 import type { Preview, StoryFn, Decorator, StoryContext } from '@storybook/react';
-import { ThemeProvider } from '@/theme/ThemeContext';
-import { DarkThemeToggle } from '@/components/DarkThemeToggle/DarkThemeToggle';
+import { ThemeProvider, useTheme } from '@/theme/ThemeContext';
 import React from 'react';
+
+const ThemeWrapper = ({ theme, children }: { theme: 'light' | 'dark'; children: React.ReactNode }) => {
+  const { setTheme } = useTheme();
+  React.useEffect(() => {
+    setTheme(theme);
+  }, [theme, setTheme]);
+  return <>{children}</>;
+};
 
 const preview: Preview = {
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
   },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+        ],
+      },
+    },
+  },
 };
 
 export const decorators: Decorator[] = [
-  (Story: StoryFn, context: StoryContext) => {
-    return (
-      <ThemeProvider>
-        <div style={{ padding: '1rem' }}>
-          <DarkThemeToggle />
-        </div>
-        <Story {...context.args} />
-      </ThemeProvider>
-    );
-  },
+  (Story: StoryFn, context: StoryContext) => (
+    <ThemeProvider>
+      <div style={{ padding: '1rem' }}>
+        <ThemeWrapper theme={context.globals.theme as 'light' | 'dark'}>
+          <Story {...context.args} />
+        </ThemeWrapper>
+      </div>
+    </ThemeProvider>
+  ),
 ];
 
 export default preview;

--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
 import { Alert } from './Alert';
 
 const meta: Meta<typeof Alert> = {
-  title: 'Components/Alert',
+  title: 'Feedback/Alert',
   component: Alert,
   args: {
     title: 'Heads up!',
@@ -18,3 +19,6 @@ type Story = StoryObj<typeof Alert>;
 export const Info: Story = {};
 export const Success: Story = { args: { variant: 'success' } };
 export const Destructive: Story = { args: { variant: 'destructive' } };
+export const WithAction: Story = {
+  args: { action: <button className="btn-sm">Undo</button> },
+};

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -4,7 +4,7 @@ void React;
 import { Avatar } from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Components/Avatar',
+  title: 'Data Display/Avatar',
   component: Avatar,
   args: {
     alt: 'JD',

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -4,7 +4,7 @@ void React;
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {
-  title: 'Components/Badge',
+  title: 'Data Display/Badge',
   component: Badge,
   args: {
     children: 'Badge',

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -4,7 +4,7 @@ void React;
 import { Breadcrumb } from './Breadcrumb';
 
 const meta: Meta<typeof Breadcrumb> = {
-  title: 'Components/Breadcrumb',
+  title: 'Navigation/Breadcrumbs',
   component: Breadcrumb,
   args: {
     items: [

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import Button from './Button';
 
 const meta: Meta<typeof Button> = {
-  title: 'Components/Button',
+  title: 'Inputs/Button',
   component: Button,
   args: {
     children: 'Button',
@@ -23,4 +23,8 @@ export const Secondary: Story = {
 };
 export const Ghost: Story = {
   args: { variant: 'ghost' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
 };

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -4,7 +4,7 @@ void React;
 import { Checkbox } from './Checkbox';
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'Components/Checkbox',
+  title: 'Inputs/Checkbox',
   component: Checkbox,
   args: {
     label: 'Accept terms',

--- a/src/components/CheckboxField/CheckboxField.stories.tsx
+++ b/src/components/CheckboxField/CheckboxField.stories.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { CheckboxField } from './CheckboxField';
 
 const meta: Meta<typeof CheckboxField> = {
-  title: 'Components/CheckboxField',
+  title: 'Inputs/CheckboxField',
   component: CheckboxField,
   argTypes: { error: { control: 'text' }, description: { control: 'text' } },
 };

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -23,7 +23,7 @@ const data: Row[] = [
 ];
 
 const meta: Meta<typeof DataTable<Row>> = {
-  title: 'Components/DataTable',
+  title: 'Data Display/DataTable',
   component: DataTable,
   args: {
     columns,
@@ -64,5 +64,15 @@ export const WithPaginationAndSelection: Story = {
         />
       </div>
     );
+  },
+};
+
+export const Sortable: Story = {
+  args: { sortable: true },
+};
+
+export const WithRowActions: Story = {
+  args: {
+    rowActions: (row: Row) => <Button size="sm">Edit {row.name}</Button>,
   },
 };

--- a/src/components/DataTable/TableToolbar.stories.tsx
+++ b/src/components/DataTable/TableToolbar.stories.tsx
@@ -4,7 +4,7 @@ import { TableToolbar } from './TableToolbar';
 import { Button } from '../Button/Button';
 
 const meta: Meta<typeof TableToolbar> = {
-  title: 'Components/TableToolbar',
+  title: 'Data Display/TableToolbar',
   component: TableToolbar,
   argTypes: {
     onSearch: { action: 'search' },

--- a/src/components/DateField/DateField.stories.tsx
+++ b/src/components/DateField/DateField.stories.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { DateField } from './DateField';
 
 const meta: Meta<typeof DateField> = {
-  title: 'Components/DateField',
+  title: 'Inputs/DateField',
   component: DateField,
   argTypes: { error: { control: 'text' } },
 };

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { DatePicker } from './DatePicker';
 
 const meta: Meta<typeof DatePicker> = {
-  title: 'Components/DatePicker',
+  title: 'Inputs/DatePicker',
   component: DatePicker,
   argTypes: { onDateChange: { action: 'changed' } },
 };

--- a/src/components/EmptyState/EmptyState.stories.tsx
+++ b/src/components/EmptyState/EmptyState.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { EmptyState } from './EmptyState';
 
 const meta: Meta<typeof EmptyState> = {
-  title: 'Components/EmptyState',
+  title: 'Data Display/EmptyState',
   component: EmptyState,
   args: {
     title: 'No items',

--- a/src/components/FileUpload/FileUpload.stories.tsx
+++ b/src/components/FileUpload/FileUpload.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { FileUpload } from './FileUpload';
 
 const meta: Meta<typeof FileUpload> = {
-  title: 'Components/FileUpload',
+  title: 'Inputs/FileUpload',
   component: FileUpload,
   argTypes: { onFileChange: { action: 'changed' } },
   args: { files: [] },

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Input } from './Input';
 
 const meta: Meta<typeof Input> = {
-  title: 'Components/Input',
+  title: 'Inputs/Input',
   component: Input,
   parameters: {
     docs: {

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { InputField } from './InputField';
 
 const meta: Meta<typeof InputField> = {
-  title: 'Components/InputField',
+  title: 'Inputs/InputField',
   component: InputField,
   argTypes: {
     layout: { control: 'select', options: ['vertical', 'inline'] },

--- a/src/components/Loader/Loader.stories.tsx
+++ b/src/components/Loader/Loader.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Loader } from './Loader';
 
 const meta: Meta<typeof Loader> = {
-  title: 'Components/Loader',
+  title: 'Feedback/Loader',
   component: Loader,
   args: {
     size: 'md',
@@ -15,3 +15,4 @@ type Story = StoryObj<typeof Loader>;
 
 export const Default: Story = {};
 export const Large: Story = { args: { size: 'lg' } };
+export const Secondary: Story = { args: { variant: 'secondary' } };

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -4,7 +4,7 @@ import { Menu } from './Menu';
 import { Button } from '../Button/Button';
 
 const meta: Meta<typeof Menu> = {
-  title: 'Components/Menu',
+  title: 'Navigation/Menu',
   component: Menu,
   args: {
     trigger: <Button>Open</Button>,

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -9,7 +9,7 @@ const options = [
 ];
 
 const meta: Meta<typeof MultiSelect> = {
-  title: 'Components/MultiSelect',
+  title: 'Inputs/MultiSelect',
   component: MultiSelect,
   args: { options },
 };

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -4,7 +4,7 @@ import { Navbar } from './Navbar';
 import { Button } from '../Button/Button';
 
 const meta: Meta<typeof Navbar> = {
-  title: 'Components/Navbar',
+  title: 'Navigation/Navbar',
   component: Navbar,
   args: {
     items: [

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Pagination } from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
-  title: 'Components/Pagination',
+  title: 'Navigation/Pagination',
   component: Pagination,
   args: {
     totalItems: 100,

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { RadioGroup } from './RadioGroup';
 
 const meta: Meta<typeof RadioGroup> = {
-  title: 'Components/RadioGroup',
+  title: 'Inputs/RadioGroup',
   component: RadioGroup,
   argTypes: {
     error: { control: 'text' },

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './Select';
 
 const meta: Meta<typeof Select> = {
-  title: 'Components/Select',
+  title: 'Inputs/Select',
   component: Select,
 };
 export default meta;

--- a/src/components/SelectField/SelectField.stories.tsx
+++ b/src/components/SelectField/SelectField.stories.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { SelectField } from './SelectField';
 
 const meta: Meta<typeof SelectField> = {
-  title: 'Components/SelectField',
+  title: 'Inputs/SelectField',
   component: SelectField,
   argTypes: { error: { control: 'text' } },
 };

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -4,7 +4,7 @@ void React;
 import { Sidebar } from './Sidebar';
 
 const meta: Meta<typeof Sidebar> = {
-  title: 'Components/Sidebar',
+  title: 'Navigation/Sidebar',
   component: Sidebar,
   args: {
     items: [

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Skeleton } from './Skeleton';
 
 const meta: Meta<typeof Skeleton> = {
-  title: 'Components/Skeleton',
+  title: 'Feedback/Skeleton',
   component: Skeleton,
   args: { width: '100%', height: '1rem' },
 };

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Switch } from './Switch';
 
 const meta: Meta<typeof Switch> = {
-  title: 'Components/Switch',
+  title: 'Inputs/Switch',
   component: Switch,
 };
 export default meta;

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from './Tabs';
 
 const meta: Meta<typeof Tabs> = {
-  title: 'Components/Tabs',
+  title: 'Navigation/Tabs',
   component: Tabs,
   args: { defaultValue: 'tab1' },
 };

--- a/src/components/TextAreaField/TextAreaField.stories.tsx
+++ b/src/components/TextAreaField/TextAreaField.stories.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { TextAreaField } from './TextAreaField';
 
 const meta: Meta<typeof TextAreaField> = {
-  title: 'Components/TextAreaField',
+  title: 'Inputs/TextAreaField',
   component: TextAreaField,
   argTypes: { error: { control: 'text' }, autoGrow: { control: 'boolean' } },
 };

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { TextField } from './TextField';
 
 const meta: Meta<typeof TextField> = {
-  title: 'Components/TextField',
+  title: 'Inputs/TextField',
   component: TextField,
   argTypes: { error: { control: 'text' } },
 };
@@ -34,4 +34,12 @@ export const WithReactHookForm: Story = {
     );
   },
   args: { id: 'name', label: 'Name' },
+};
+
+export const Disabled: Story = {
+  args: { id: 'disabled', label: 'Disabled', disabled: true },
+};
+
+export const WithError: Story = {
+  args: { id: 'error', label: 'Error field', error: 'Required' },
 };

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -4,7 +4,7 @@ void React;
 import { Textarea } from './Textarea';
 
 const meta: Meta<typeof Textarea> = {
-  title: 'Components/Textarea',
+  title: 'Inputs/Textarea',
   component: Textarea,
   args: { placeholder: 'Enter text' },
 };

--- a/src/docs/GuiaDeUso.stories.tsx
+++ b/src/docs/GuiaDeUso.stories.tsx
@@ -1,0 +1,105 @@
+import { useMDXComponents as _provideComponents } from "@mdx-js/react";
+import { Meta } from '@storybook/blocks';
+import { jsx as _jsx } from "react/jsx-runtime";
+import { jsxs as _jsxs } from "react/jsx-runtime";
+import { Fragment as _Fragment } from "react/jsx-runtime";
+function _createMdxContent(props) {
+  const _components = Object.assign({
+    h1: "h1",
+    p: "p",
+    h2: "h2",
+    ol: "ol",
+    li: "li",
+    code: "code",
+    ul: "ul",
+    em: "em",
+    pre: "pre"
+  }, _provideComponents(), props.components);
+  return /*#__PURE__*/_jsxs(_Fragment, {
+    children: [/*#__PURE__*/_jsx(Meta, {
+      title: "Docs/Guia de uso"
+    }), "\n", /*#__PURE__*/_jsx(_components.h1, {
+      children: "Gu\\u00eda de uso del Design System"
+    }), "\n", /*#__PURE__*/_jsx(_components.p, {
+      children: "Esta gu\\u00eda resume c\\u00f3mo contribuir con nuevas historias y buenas pr\\u00e1cticas."
+    }), "\n", /*#__PURE__*/_jsx(_components.h2, {
+      children: "C\\u00f3mo contribuir"
+    }), "\n", /*#__PURE__*/_jsxs(_components.ol, {
+      children: ["\n", /*#__PURE__*/_jsxs(_components.li, {
+        children: ["Agrega tu componente en ", /*#__PURE__*/_jsx(_components.code, {
+          children: "src/components"
+        }), " con sus pruebas."]
+      }), "\n", /*#__PURE__*/_jsx(_components.li, {
+        children: "Crea su historia bajo la misma carpeta."
+      }), "\n", /*#__PURE__*/_jsxs(_components.li, {
+        children: ["Aseg\\u00farate de exportar un ", /*#__PURE__*/_jsx(_components.code, {
+          children: "meta"
+        }), " con ", /*#__PURE__*/_jsx(_components.code, {
+          children: "title"
+        }), " y ", /*#__PURE__*/_jsx(_components.code, {
+          children: "component"
+        }), "."]
+      }), "\n"]
+    }), "\n", /*#__PURE__*/_jsx(_components.h2, {
+      children: "Criterios de accesibilidad"
+    }), "\n", /*#__PURE__*/_jsxs(_components.ul, {
+      children: ["\n", /*#__PURE__*/_jsx(_components.li, {
+        children: "Usa atributos ARIA cuando corresponda."
+      }), "\n", /*#__PURE__*/_jsx(_components.li, {
+        children: "Verifica la navegaci\\u00f3n por teclado."
+      }), "\n", /*#__PURE__*/_jsx(_components.li, {
+        children: "Asegura contraste suficiente en modo claro y oscuro."
+      }), "\n"]
+    }), "\n", /*#__PURE__*/_jsx(_components.h2, {
+      children: "Convenciones de nomenclatura"
+    }), "\n", /*#__PURE__*/_jsxs(_components.ul, {
+      children: ["\n", /*#__PURE__*/_jsxs(_components.li, {
+        children: ["Componentes en ", /*#__PURE__*/_jsx(_components.em, {
+          children: "PascalCase"
+        }), "."]
+      }), "\n", /*#__PURE__*/_jsxs(_components.li, {
+        children: ["Archivos de historia terminan en ", /*#__PURE__*/_jsx(_components.code, {
+          children: ".stories.tsx"
+        }), " o ", /*#__PURE__*/_jsx(_components.code, {
+          children: ".stories.mdx"
+        }), "."]
+      }), "\n"]
+    }), "\n", /*#__PURE__*/_jsx(_components.h2, {
+      children: "Ejemplo de estructura ideal"
+    }), "\n", /*#__PURE__*/_jsx(_components.pre, {
+      children: /*#__PURE__*/_jsx(_components.code, {
+        className: "language-tsx",
+        children: "import type { Meta, StoryObj } from '@storybook/react';\nimport { Button } from './Button';\n\nconst meta: Meta<typeof Button> = {\n  title: 'Inputs/Button',\n  component: Button,\n};\nexport default meta;\n\nexport const Primary: StoryObj<typeof Button> = {\n  args: { children: 'Enviar' },\n};\n"
+      })
+    })]
+  });
+}
+function MDXContent(props = {}) {
+  const {
+    wrapper: MDXLayout
+  } = Object.assign({}, _provideComponents(), props.components);
+  return MDXLayout ? /*#__PURE__*/_jsx(MDXLayout, {
+    ...props,
+    children: /*#__PURE__*/_jsx(_createMdxContent, {
+      ...props
+    })
+  }) : _createMdxContent(props);
+}
+/* ========= */
+export const __page = () => {
+  throw new Error("Docs-only story");
+};
+__page.parameters = {
+  docsOnly: true
+};
+const componentMeta = {
+  title: 'Docs/Guia de uso',
+  tags: ['stories-mdx'],
+  includeStories: ["__page"]
+};
+componentMeta.parameters = componentMeta.parameters || {};
+componentMeta.parameters.docs = {
+  ...(componentMeta.parameters.docs || {}),
+  page: MDXContent
+};
+export default componentMeta;


### PR DESCRIPTION
## Summary
- organize stories into new categories like Inputs, Feedback, Navigation
- add dark/light toolbar and global theme sync
- document usage guidelines via `Docs/Guia de uso`
- expand some component stories with extra states
- fix Storybook build by compiling docs to TSX

## Testing
- `pnpm test`
- `CI=true pnpm build-storybook`


------
https://chatgpt.com/codex/tasks/task_e_68568b8464748325a36b061102240254