### PR TITLE
Add AppLayout and Login components

### DIFF
--- a/src/components/AppLayout/AppLayout.stories.tsx
+++ b/src/components/AppLayout/AppLayout.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { AppLayout } from './AppLayout';
+import { Navbar } from '../Navbar';
+import { Sidebar } from '../Sidebar';
+
+const meta: Meta<typeof AppLayout> = {
+  title: 'Layout/AppLayout',
+  component: AppLayout,
+  args: {
+    navbar: <Navbar items={[{ label: 'Home', href: '#' }]} />,
+    sidebar: <Sidebar items={[{ label: 'Dashboard', href: '#' }]} />,
+    children: <div>Content</div>,
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof AppLayout>;
+
+export const Primary: Story = {};

--- a/src/components/AppLayout/AppLayout.test.tsx
+++ b/src/components/AppLayout/AppLayout.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+import { AppLayout } from './AppLayout';
+import { Navbar } from '../Navbar';
+import { Sidebar } from '../Sidebar';
+
+describe('AppLayout', () => {
+  it('renders without accessibility violations', async () => {
+    const { container } = render(
+      <AppLayout
+        navbar={
+          <Navbar
+            items={[{ label: 'Home', href: '#' }]}
+            aria-label="main navigation"
+          />
+        }
+        sidebar={
+          <Sidebar
+            items={[{ label: 'Dashboard', href: '#' }]}
+            aria-label="sidebar"
+          />
+        }
+      >
+        <div>Content</div>
+      </AppLayout>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export interface AppLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
+  navbar?: React.ReactNode;
+  sidebar?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * Provides a basic application layout with optional navbar and sidebar.
+ */
+export const AppLayout = React.forwardRef<HTMLDivElement, AppLayoutProps>(
+  ({ navbar, sidebar, children, className, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={clsx('flex flex-col min-h-screen', className)}
+        {...props}
+      >
+        {navbar}
+        <div className="flex flex-1">
+          {sidebar}
+          <main className="flex-1 p-[var(--spacing-md)]">{children}</main>
+        </div>
+      </div>
+    );
+  }
+);
+
+AppLayout.displayName = 'AppLayout';
+
+export default AppLayout;

--- a/src/components/AppLayout/index.ts
+++ b/src/components/AppLayout/index.ts
@@ -1,0 +1,2 @@
+export { AppLayout } from './AppLayout';
+export type { AppLayoutProps } from './AppLayout';

--- a/src/components/Login/Login.stories.tsx
+++ b/src/components/Login/Login.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Login } from './Login';
+
+const meta: Meta<typeof Login> = {
+  title: 'Components/Login',
+  component: Login,
+};
+export default meta;
+
+type Story = StoryObj<typeof Login>;
+
+export const Primary: Story = {
+  render: () => <Login onSubmit={(e) => e.preventDefault()} />,
+};

--- a/src/components/Login/Login.test.tsx
+++ b/src/components/Login/Login.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, it, expect } from 'vitest';
+import { Login } from './Login';
+
+describe('Login', () => {
+  it('renders without accessibility violations', async () => {
+    const { container } = render(
+      <Login onSubmit={(e) => e.preventDefault()} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { TextField } from '../TextField';
+import Button from '../Button/Button';
+
+export interface LoginProps extends React.FormHTMLAttributes<HTMLFormElement> {
+  onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
+}
+
+/**
+ * Simple login form with email and password fields.
+ */
+export const Login = React.forwardRef<HTMLFormElement, LoginProps>(
+  ({ onSubmit, className, ...props }, ref) => {
+    return (
+      <form ref={ref} className={className} onSubmit={onSubmit} {...props}>
+        <div className="flex flex-col gap-[var(--spacing-md)] w-64">
+          <TextField id="email" label="Email" type="email" required />
+          <TextField id="password" label="Password" type="password" required />
+          <Button type="submit">Login</Button>
+        </div>
+      </form>
+    );
+  }
+);
+
+Login.displayName = 'Login';
+
+export default Login;

--- a/src/components/Login/index.ts
+++ b/src/components/Login/index.ts
@@ -1,0 +1,2 @@
+export { Login } from './Login';
+export type { LoginProps } from './Login';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -50,3 +50,5 @@ export * from './Sidebar';
 export * from './Menu';
 export * from './DataTable';
 export * from './Skeleton';
+export * from './AppLayout';
+export * from './Login';


### PR DESCRIPTION
## Summary
- add `AppLayout` layout component
- add `Login` form component
- create stories and tests
- export new components from index

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a2acb4408325b0d92fb1ab022fa9