### PR TITLE
Fix Storybook actions for DataTable

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
+import { fn } from '@storybook/test';
 import { DataTable } from './DataTable';
 import type { DataTablePagination } from './DataTable';
 import { TableToolbar } from './TableToolbar';
@@ -28,6 +29,8 @@ const meta: Meta<typeof DataTable> = {
   args: {
     columns,
     data,
+    onRowClick: fn(),
+    onRowSelect: fn(),
   },
 };
 export default meta;

--- a/src/components/DataTable/TableToolbar.stories.tsx
+++ b/src/components/DataTable/TableToolbar.stories.tsx
@@ -1,14 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import { fn } from '@storybook/test';
 import { TableToolbar } from './TableToolbar';
 import { Button } from '../Button/Button';
 
 const meta: Meta<typeof TableToolbar> = {
   title: 'Data Display/TableToolbar',
   component: TableToolbar,
-  argTypes: {
-    onSearch: { action: 'search' },
-  },
   args: {
     count: 3,
     actions: <Button>New</Button>,
@@ -21,5 +19,5 @@ type Story = StoryObj<typeof TableToolbar>;
 export const Default: Story = {};
 
 export const WithSearch: Story = {
-  args: { onSearch: () => {} },
+  args: { onSearch: fn() },
 };


### PR DESCRIPTION
## Summary
- provide explicit action spies for DataTable story props
- switch TableToolbar stories to use spies instead of argTypes

## Testing
- `pnpm exec vitest run`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6856a7b2dffc8325aed3b2a2d01591ac