### PR TITLE
Add futuristic theme

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import type { Preview, StoryFn, Decorator, StoryContext } from '@storybook/react
 import { ThemeProvider, useTheme } from '@/theme/ThemeContext';
 import React from 'react';
 
-const ThemeWrapper = ({ theme, children }: { theme: 'light' | 'dark'; children: React.ReactNode }) => {
+const ThemeWrapper = ({ theme, children }: { theme: 'light' | 'dark' | 'futuristic'; children: React.ReactNode }) => {
   const { setTheme } = useTheme();
   React.useEffect(() => {
     setTheme(theme);
@@ -26,6 +26,7 @@ const preview: Preview = {
         items: [
           { value: 'light', title: 'Light' },
           { value: 'dark', title: 'Dark' },
+          { value: 'futuristic', title: 'Futuristic' },
         ],
       },
     },
@@ -36,7 +37,7 @@ export const decorators: Decorator[] = [
   (Story: StoryFn, context: StoryContext) => (
     <ThemeProvider>
       <div style={{ padding: '1rem' }}>
-        <ThemeWrapper theme={context.globals.theme as 'light' | 'dark'}>
+        <ThemeWrapper theme={context.globals.theme as 'light' | 'dark' | 'futuristic'}>
           <Story {...context.args} />
         </ThemeWrapper>
       </div>

--- a/index.css
+++ b/index.css
@@ -37,6 +37,9 @@
   --ring: #020817;
   --radius: 0.5rem;
   --font-family-base: system-ui, sans-serif;
+  --font-family-body: var(--font-family-base);
+  --font-family-heading: var(--font-family-base);
+  --font-family-mono: monospace;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
   --font-size-md: 1rem;
@@ -89,6 +92,37 @@
   --border: #27272a;
   --input: #27272a;
   --ring: #fafafa;
+}
+
+[data-theme='futuristic'] {
+  --background: #0F0F1A;
+  --foreground: #ffffffcc;
+  --card: #1F1F2B;
+  --card-foreground: #ffffffcc;
+  --popover: #1F1F2B;
+  --popover-foreground: #ffffffcc;
+  --primary: #7F5AF0;
+  --primary-foreground: #0F0F1A;
+  --secondary: #2CB67D;
+  --secondary-foreground: #0F0F1A;
+  --muted: #1F1F2B;
+  --muted-foreground: #ffffffcc;
+  --accent: #2CB67D;
+  --accent-foreground: #0F0F1A;
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+  --success: #2CB67D;
+  --success-foreground: #0F0F1A;
+  --warning: #facc15;
+  --warning-foreground: #78350f;
+  --info: #7F5AF0;
+  --info-foreground: #ffffff;
+  --border: #7F5AF0;
+  --input: #7F5AF0;
+  --ring: #7F5AF0;
+  --font-family-body: 'Inter', 'IBM Plex Sans', sans-serif;
+  --font-family-heading: 'Geist', 'Satoshi', sans-serif;
+  --font-family-mono: 'SF Mono', monospace;
 }
 
 body {
@@ -344,6 +378,21 @@ p {
   background-color: #17a2b8;
   border-color: #4dd3e9;
   color: #d1ecf1;
+}
+[data-theme='futuristic'] .alert-success {
+  background-color: #2CB67D;
+  border-color: #2CB67D;
+  color: #0F0F1A;
+}
+[data-theme='futuristic'] .alert-warning {
+  background-color: #7F5AF0;
+  border-color: #7F5AF0;
+  color: #ffffff;
+}
+[data-theme='futuristic'] .alert-info {
+  background-color: #1F1F2B;
+  border-color: #7F5AF0;
+  color: #ffffffcc;
 }
 
 /* Avatar */
@@ -1654,7 +1703,7 @@ p {
 }
 /* Text */
 .text {
-  font-family: var(--font-family-base);
+  font-family: var(--font-family-body);
   line-height: 1.5;
 }
 .text--xs {
@@ -1696,7 +1745,7 @@ p {
 
 /* Heading */
 .heading {
-  font-family: var(--font-family-base);
+  font-family: var(--font-family-heading);
   font-weight: 700;
   line-height: 1.2;
 }

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { motion, type HTMLMotionProps } from 'framer-motion';
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
@@ -9,7 +10,7 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   onClose?: () => void;
 }
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+const Alert = React.forwardRef<HTMLDivElement, HTMLMotionProps<'div'> & AlertProps>(
   (
     {
       className,
@@ -27,10 +28,13 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
     const variantClass = `alert-${variant}`;
 
     return (
-      <div
+      <motion.div
         ref={ref}
         role="alert"
         className={`alert ${variantClass} ${className || ''}`}
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.2 }}
         {...props}
       >
         {icon && <span className="alert-icon">{icon}</span>}
@@ -52,7 +56,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
             &times;
           </button>
         )}
-      </div>
+      </motion.div>
     );
   }
 );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -49,7 +49,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={classes}
         aria-disabled={disabled}
         whileHover={{ scale: disabled ? 1 : 1.02 }}
-        whileFocus={{ scale: disabled ? 1 : 1.02 }}
+        whileFocus={{ scale: disabled ? 1 : 1.02, boxShadow: disabled ? 'none' : '0 0 0 4px var(--ring)' }}
         transition={{ duration: 0.15 }}
         disabled={disabled}
         {...props}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react';
+import { motion, type HTMLMotionProps } from 'framer-motion';
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+const Card = React.forwardRef<HTMLDivElement, HTMLMotionProps<'div'>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={`card ${className || ''}`} {...props} />
+    <motion.div
+      ref={ref}
+      className={`card ${className || ''}`}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.3 }}
+      {...props}
+    />
   ),
 );
 Card.displayName = 'Card';

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
+import { motion } from 'framer-motion';
 import {
   ColumnDef,
   flexRender,
@@ -117,7 +118,12 @@ export function DataTable<TData extends { id: React.Key }>({
   const colLength = table.getVisibleLeafColumns().length;
 
   return (
-    <div className={clsx('overflow-x-auto', className)}>
+    <motion.div
+      className={clsx('overflow-x-auto', className)}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+    >
       <table className="w-full border-collapse mb-4">
         <thead>
           {headers.map((headerGroup) => (
@@ -199,7 +205,7 @@ export function DataTable<TData extends { id: React.Key }>({
           />
         </div>
       )}
-    </div>
+    </motion.div>
   );
 }
 

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { motion } from 'framer-motion';
 
 export interface DialogProps {
   isOpen: boolean;
@@ -23,17 +24,26 @@ export const Dialog = ({ isOpen, onClose, children, className }: DialogProps) =>
   }
 
   return (
-    <div className="dialog-overlay" onClick={onClose}>
-      <div
+    <motion.div
+      className="dialog-overlay"
+      onClick={onClose}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+    >
+      <motion.div
         className={`dialog-content ${className || ''}`}
         onClick={(e) => e.stopPropagation()}
+        initial={{ scale: 0.9 }}
+        animate={{ scale: 1 }}
+        transition={{ duration: 0.2 }}
       >
         <button className="dialog-close" onClick={onClose} aria-label="Close">
           &times;
         </button>
         {children}
-      </div>
-    </div>
+      </motion.div>
+    </motion.div>
   );
 };
 

--- a/src/docs/IdentidadVisual.stories.tsx
+++ b/src/docs/IdentidadVisual.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+  title: 'Docs/Identidad Visual',
+  parameters: {
+    viewMode: 'docs',
+    docs: {
+      page: () => (
+        <>
+          <h1>Identidad visual</h1>
+          <p>El tema futurista utiliza una paleta vibrante y tipografías modernas.</p>
+          <ul>
+            <li>Primary: #7F5AF0</li>
+            <li>Accent: #2CB67D</li>
+            <li>Background: #0F0F1A</li>
+            <li>Surface: #1F1F2B</li>
+            <li>Texto: #FFFFFFCC</li>
+          </ul>
+          <p>
+            Los encabezados emplean fuentes como Geist o Satoshi mientras que el
+            cuerpo utiliza Inter o IBM Plex Sans.
+          </p>
+        </>
+      ),
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+export const Page: Story = {};
+Page.parameters = { docsOnly: true };

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
-export type Theme = 'light' | 'dark';
+export type Theme = 'light' | 'dark' | 'futuristic';
 const THEME_KEY = 'vite-ui-theme';
 
 interface ThemeProviderState {
@@ -13,7 +13,7 @@ const ThemeProviderContext = createContext<ThemeProviderState | undefined>(undef
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   const [theme, setThemeState] = useState<Theme>(() => {
     const stored = localStorage.getItem(THEME_KEY) as Theme | null;
-    if (stored === 'light' || stored === 'dark') {
+    if (stored === 'light' || stored === 'dark' || stored === 'futuristic') {
       return stored;
     }
     return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -23,15 +23,14 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     const root = window.document.documentElement;
-    const isDark = theme === 'dark';
 
     // Remove old theme classes and data-theme attribute
-    root.classList.remove('light', 'dark');
+    root.classList.remove('light', 'dark', 'futuristic');
     root.removeAttribute('data-theme');
 
-    if (isDark) {
-      root.classList.add('dark');
-      root.setAttribute('data-theme', 'dark');
+    if (theme === 'dark' || theme === 'futuristic') {
+      root.classList.add(theme);
+      root.setAttribute('data-theme', theme);
     } else {
       root.classList.add('light');
     }

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,4 @@
-export { theme, lightTheme, darkTheme } from './theme';
+export { theme, lightTheme, darkTheme, futuristicTheme } from './theme';
 export type { DesignTokens } from './theme';
 export { ThemeProvider, useTheme } from './ThemeContext';
 export type { Theme } from './ThemeContext';

--- a/src/theme/theme.futuristic.ts
+++ b/src/theme/theme.futuristic.ts
@@ -1,0 +1,24 @@
+import { lightTheme, ThemeTokens } from './theme.light';
+
+export const futuristicTheme: ThemeTokens = {
+  colors: {
+    primary: '#7F5AF0',
+    primaryForeground: '#0F0F1A',
+    secondary: '#2CB67D',
+    secondaryForeground: '#0F0F1A',
+    neutral100: '#0F0F1A',
+    neutral900: '#ffffffcc',
+  },
+  typography: {
+    fontFamily: "'Inter', 'IBM Plex Sans', sans-serif",
+    fontSize: lightTheme.typography.fontSize,
+  },
+  spacing: lightTheme.spacing,
+  motion: lightTheme.motion,
+  breakpoints: lightTheme.breakpoints,
+  radius: '0.5rem',
+  zIndex: lightTheme.zIndex,
+  borders: {
+    color: '#7F5AF0',
+  },
+} as const;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,8 +1,9 @@
 import { lightTheme, ThemeTokens } from './theme.light';
 import { darkTheme } from './theme.dark';
+import { futuristicTheme } from './theme.futuristic';
 
 export type DesignTokens = ThemeTokens;
 
-export { lightTheme, darkTheme };
+export { lightTheme, darkTheme, futuristicTheme };
 export const theme = lightTheme;
 export default theme;

--- a/tailwind.preset.js
+++ b/tailwind.preset.js
@@ -4,8 +4,16 @@ module.exports = {
   darkMode: 'class', // or 'media' or 'selector'
   theme: {
     extend: {
-      // Extend Tailwind's default theme here
-      // colors: { primary: '#...' },
+      colors: {
+        background: 'var(--background)',
+        primary: 'var(--primary)',
+        accent: 'var(--accent)',
+      },
+      fontFamily: {
+        body: 'var(--font-family-body)',
+        heading: 'var(--font-family-heading)',
+        mono: 'var(--font-family-mono)',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- add futuristic theme tokens and docs
- extend theme provider and storybook for futuristic
- include CSS vars and fonts for futuristic mode
- animate components with framer-motion
- expose css vars in tailwind preset

## Testing
- `npm test`
- `npm run build-storybook`

------
https://chatgpt.com/codex/tasks/task_e_6856a991a314832590591b7a20db8f9c