### PR TITLE
Add futuristic theme toggle support in Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,10 +1,21 @@
 // Import Tailwind CSS with design system styles
 import './tailwind.css';
-import type { Preview, StoryFn, Decorator, StoryContext } from '@storybook/react';
-import { ThemeProvider, useTheme } from '@/theme/ThemeContext';
+import type {
+  Preview,
+  StoryFn,
+  Decorator,
+  StoryContext,
+} from '@storybook/react';
+import { ThemeProvider, useTheme, type Theme } from '@/theme/ThemeContext';
 import React from 'react';
 
-const ThemeWrapper = ({ theme, children }: { theme: 'light' | 'dark' | 'futuristic'; children: React.ReactNode }) => {
+const ThemeWrapper = ({
+  theme,
+  children,
+}: {
+  theme: Theme;
+  children: React.ReactNode;
+}) => {
   const { setTheme } = useTheme();
   React.useEffect(() => {
     setTheme(theme);
@@ -37,7 +48,7 @@ export const decorators: Decorator[] = [
   (Story: StoryFn, context: StoryContext) => (
     <ThemeProvider>
       <div style={{ padding: '1rem' }}>
-        <ThemeWrapper theme={context.globals.theme as 'light' | 'dark' | 'futuristic'}>
+        <ThemeWrapper theme={context.globals.theme as Theme}>
           <Story {...context.args} />
         </ThemeWrapper>
       </div>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A comprehensive design system built with React, TypeScript, and CSS. This system
 ```
 design-system/
 ├── components/           # Componentes de UI reutilizables
-│   ├── Button/          
+│   ├── Button/
 │   │   ├── Button.tsx    # Componente Button
 │   │   └── Button.css    # Estilos del componente Button
 │   └── ...              # Otros componentes
@@ -33,6 +33,7 @@ Para más detalles sobre la estructura, consulta [PROJECT_STRUCTURE.md](./PROJEC
 ## 🛠 Instalación
 
 1. Clona el repositorio:
+
    ```bash
    git clone [URL_DEL_REPOSITORIO]
    cd design-system
@@ -43,13 +44,12 @@ Para más detalles sobre la estructura, consulta [PROJECT_STRUCTURE.md](./PROJEC
    pnpm install
    ```
 
-
 ## 🧩 Componentes
 
 ### Componentes Disponibles
 
 - **Button** - Botón versátil para diversas acciones
-- *Más componentes serán agregados...*
+- _Más componentes serán agregados..._
 
 ## 📚 Documentación
 
@@ -149,6 +149,10 @@ module.exports = {
 };
 ```
 
+### Themes in Storybook
+
+Storybook includes **light**, **dark**, and **futuristic** themes. Use the theme selector in the Storybook toolbar to switch between them. Your selection is stored in local storage so it persists while navigating between stories.
+
 ### Migration Guide
 
 If you're upgrading from a previous version, please see our [Migration Guide](./MIGRATION_GUIDE.md) for instructions on updating your components to use the new design tokens system.
@@ -158,11 +162,14 @@ If you're upgrading from a previous version, please see our [Migration Guide](./
 ### Installation
 
 To use this design system in your project, install it via npm or yarn.
+
 ```
 bash
 npm install my-design-system
 ```
+
 or
+
 ```
 bash
 yarn add my-design-system
@@ -192,6 +199,7 @@ import '@k2600x/design-system/style.css';
 ```
 
 Import the components you need from the package:
+
 ```
 typescript
 import { Button, Input } from 'my-design-system';
@@ -206,6 +214,7 @@ function MyComponent() {
 }
 
 ```
+
 ## Contributing
 
 Contributions are welcome! Please read our contributing guidelines for more information.

--- a/src/components/DarkThemeToggle/DarkThemeToggle.stories.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.stories.tsx
@@ -29,3 +29,14 @@ export const InitialDark: Story = {
     );
   },
 };
+
+export const InitialFuturistic: Story = {
+  render: () => {
+    localStorage.setItem('vite-ui-theme', 'futuristic');
+    return (
+      <ThemeProvider>
+        <DarkThemeToggle />
+      </ThemeProvider>
+    );
+  },
+};

--- a/src/components/DarkThemeToggle/DarkThemeToggle.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.tsx
@@ -2,9 +2,20 @@ import React from 'react';
 import { useTheme } from '../../theme/ThemeContext';
 import { Button } from '../Button/Button';
 
-// Basic SVG icons for sun and moon
+// Basic SVG icons for sun, moon and star
 const SunIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
     <circle cx="12" cy="12" r="5"></circle>
     <line x1="12" y1="1" x2="12" y2="3"></line>
     <line x1="12" y1="21" x2="12" y2="23"></line>
@@ -18,8 +29,36 @@ const SunIcon = (props: React.SVGProps<SVGSVGElement>) => (
 );
 
 const MoonIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
     <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+);
+
+const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <polygon points="12 2 15 8 22 9 17 14 18 21 12 18 6 21 7 14 2 9 9 8 12 2" />
   </svg>
 );
 
@@ -27,16 +66,20 @@ export const DarkThemeToggle = () => {
   const { theme, setTheme } = useTheme();
 
   const toggleTheme = () => {
-    setTheme(theme === 'dark' ? 'light' : 'dark');
+    const next =
+      theme === 'light' ? 'dark' : theme === 'dark' ? 'futuristic' : 'light';
+    setTheme(next);
   };
 
   return (
-    <Button onClick={toggleTheme} className="btn-outline btn-icon" aria-label="Toggle dark mode">
-      {theme === 'dark' ? (
-        <SunIcon className="h-[1.2rem] w-[1.2rem]" />
-      ) : (
-        <MoonIcon className="h-[1.2rem] w-[1.2rem]" />
-      )}
+    <Button
+      onClick={toggleTheme}
+      className="btn-outline btn-icon"
+      aria-label="Toggle theme"
+    >
+      {theme === 'light' && <MoonIcon className="h-[1.2rem] w-[1.2rem]" />}
+      {theme === 'dark' && <StarIcon className="h-[1.2rem] w-[1.2rem]" />}
+      {theme === 'futuristic' && <SunIcon className="h-[1.2rem] w-[1.2rem]" />}
     </Button>
   );
 };


### PR DESCRIPTION
## Summary
- support a `Theme` type in storybook preview and update decorator
- cycle through light/dark/futuristic in DarkThemeToggle
- document the available themes in Storybook
- add story demonstrating the futuristic theme

## Testing
- `npm test`
- `npm run build`
- `npm run test:coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_6856b1facee48325b851844e4d1645e3