### PR TITLE
Fix storybook stories

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -20,5 +20,9 @@ export const Info: Story = {};
 export const Success: Story = { args: { variant: 'success' } };
 export const Destructive: Story = { args: { variant: 'destructive' } };
 export const WithAction: Story = {
-  args: { action: <button className="btn-sm">Undo</button> },
+  render: (args) => (
+    <Alert {...args}>
+      <button className="btn-sm">Undo</button>
+    </Alert>
+  ),
 };

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { fn } from '@storybook/test';
 import { DataTable } from './DataTable';
 import type { DataTablePagination } from './DataTable';
+import type { ColumnDef } from '@tanstack/react-table';
 import { TableToolbar } from './TableToolbar';
 import { Button } from '../Button/Button';
 
@@ -12,10 +13,10 @@ interface Row {
   age: number;
 }
 
-const columns = [
+const columns: ColumnDef<Row>[] = [
   { accessorKey: 'name', header: 'Name' },
   { accessorKey: 'age', header: 'Age' },
-] as const;
+];
 
 const data: Row[] = [
   { id: 1, name: 'Alice', age: 30 },
@@ -23,7 +24,7 @@ const data: Row[] = [
   { id: 3, name: 'Charlie', age: 28 },
 ];
 
-const meta: Meta<typeof DataTable> = {
+const meta: Meta<typeof DataTable<Row>> = {
   title: 'Data Display/DataTable',
   component: DataTable,
   args: {
@@ -35,7 +36,7 @@ const meta: Meta<typeof DataTable> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof DataTable>;
+type Story = StoryObj<typeof DataTable<Row>>;
 
 export const WithData: Story = {};
 

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -3,13 +3,14 @@ import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { describe, it, expect } from 'vitest';
 import { DataTable } from './DataTable';
+import type { ColumnDef } from '@tanstack/react-table';
 
 interface Row {
   id: number;
   name: string;
 }
 
-const columns = [{ accessorKey: 'name', header: 'Name' }] as const;
+const columns: ColumnDef<Row>[] = [{ accessorKey: 'name', header: 'Name' }];
 
 const data: Row[] = [{ id: 1, name: 'Alice' }];
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -9,7 +9,7 @@ interface Row {
   age: number;
 }
 
-const columns = [
+const columns: { accessorKey: keyof Row; header: string }[] = [
   { accessorKey: 'name', header: 'Name' },
   { accessorKey: 'age', header: 'Age' },
 ];

--- a/src/examples/VisualMockup.stories.tsx
+++ b/src/examples/VisualMockup.stories.tsx
@@ -19,6 +19,7 @@ import Button from '@/components/Button/Button';
 import { Stack } from '@/components/Stack';
 import { Grid } from '@/components/Grid';
 import { useTheme } from '@/theme/ThemeContext';
+import type { ColumnDef } from '@tanstack/react-table';
 
 interface Row {
   id: number;
@@ -26,10 +27,10 @@ interface Row {
   visits: number;
 }
 
-const columns = [
+const columns: ColumnDef<Row>[] = [
   { accessorKey: 'name', header: 'Name' },
   { accessorKey: 'visits', header: 'Visits' },
-] as const;
+];
 
 const data: Row[] = [
   { id: 1, name: 'Alice', visits: 120 },


### PR DESCRIPTION
## Summary
- fix Alert story action usage
- type stories and tests with ColumnDef
- clarify column typing in Table story
- include ColumnDef typings in visual mockup story

## Testing
- `npm run type-check`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6856be6c43d08325bed519d61b74b794