### PR TITLE
Enhance futuristic theme visuals

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,6 +8,7 @@ import type {
 } from '@storybook/react';
 import { ThemeProvider, useTheme, type Theme } from '@/theme/ThemeContext';
 import React from 'react';
+import clsx from 'clsx';
 
 const ThemeWrapper = ({
   theme,
@@ -21,6 +22,16 @@ const ThemeWrapper = ({
     setTheme(theme);
   }, [theme, setTheme]);
   return <>{children}</>;
+};
+
+const FuturisticDecorator = ({ children }: { children: React.ReactNode }) => {
+  const { theme } = useTheme();
+  return (
+    <div className={clsx(theme === 'futuristic' && 'futuristic-wrap')}>
+      {theme === 'futuristic' && <div className="futuristic-bg" aria-hidden />}
+      {children}
+    </div>
+  );
 };
 
 const preview: Preview = {
@@ -49,7 +60,9 @@ export const decorators: Decorator[] = [
     <ThemeProvider>
       <div style={{ padding: '1rem' }}>
         <ThemeWrapper theme={context.globals.theme as Theme}>
-          <Story {...context.args} />
+          <FuturisticDecorator>
+            <Story {...context.args} />
+          </FuturisticDecorator>
         </ThemeWrapper>
       </div>
     </ThemeProvider>

--- a/index.css
+++ b/index.css
@@ -125,6 +125,55 @@
   --font-family-mono: 'SF Mono', monospace;
 }
 
+/* Futuristic theme visuals */
+.futuristic-wrap {
+  position: relative;
+}
+
+.futuristic-bg {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(127, 90, 240, 0.25), transparent 70%);
+  animation: futuristic-pan 12s ease-in-out infinite alternate;
+}
+
+@keyframes futuristic-pan {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.4);
+  }
+}
+
+.skeleton-glow {
+  position: relative;
+  overflow: hidden;
+}
+
+.skeleton-glow::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transform: translateX(-100%);
+  animation: skeleton-glow 1.5s infinite;
+}
+
+@keyframes skeleton-glow {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes alert-fade-in {
+  to {
+    opacity: 1;
+  }
+}
+
 body {
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
@@ -303,10 +352,13 @@ p {
   width: 100%;
   border-radius: var(--radius);
   border: 1px solid;
+  box-shadow: 0 0 8px rgba(127, 90, 240, 0.3);
   padding: 1rem;
   margin-bottom: 1rem;
   display: flex;
   align-items: flex-start;
+  opacity: 0;
+  animation: alert-fade-in 0.3s forwards;
 }
 
 .alert-title {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,8 +48,15 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={classes}
         aria-disabled={disabled}
-        whileHover={{ scale: disabled ? 1 : 1.02 }}
-        whileFocus={{ scale: disabled ? 1 : 1.02, boxShadow: disabled ? 'none' : '0 0 0 4px var(--ring)' }}
+        whileHover={{
+          scale: disabled ? 1 : 1.05,
+          boxShadow: disabled ? 'none' : '0 0 0 4px var(--ring)',
+          filter: disabled ? 'none' : 'brightness(1.1)',
+        }}
+        whileFocus={{
+          scale: disabled ? 1 : 1.05,
+          boxShadow: disabled ? 'none' : '0 0 0 4px var(--ring)',
+        }}
         transition={{ duration: 0.15 }}
         disabled={disabled}
         {...props}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -6,9 +6,9 @@ const Card = React.forwardRef<HTMLDivElement, HTMLMotionProps<'div'>>(
     <motion.div
       ref={ref}
       className={`card ${className || ''}`}
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.3 }}
+      initial={{ opacity: 0, y: 20, filter: 'blur(4px)' }}
+      animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+      transition={{ duration: 0.4 }}
       {...props}
     />
   ),

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -34,9 +34,9 @@ export const Dialog = ({ isOpen, onClose, children, className }: DialogProps) =>
       <motion.div
         className={`dialog-content ${className || ''}`}
         onClick={(e) => e.stopPropagation()}
-        initial={{ scale: 0.9 }}
-        animate={{ scale: 1 }}
-        transition={{ duration: 0.2 }}
+        initial={{ opacity: 0, x: 40 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.3 }}
       >
         <button className="dialog-close" onClick={onClose} aria-label="Close">
           &times;

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { motion } from 'framer-motion';
 
 
 export interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -70,11 +71,13 @@ const Loader = React.forwardRef<HTMLDivElement, LoaderProps>((
       {...ariaProps}
       {...props}
     >
-      <div 
+      <motion.div
         className={`loader loader--${size} loader--${variant}`}
+        animate={{ rotate: 360 }}
+        transition={{ repeat: Infinity, ease: 'linear', duration: 1 }}
       >
         {/* The sr-only text was removed as aria-label on the container is sufficient */}
-      </div>
+      </motion.div>
     </div>
   );
 });

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -14,7 +14,7 @@ export const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
       <div
         ref={ref}
         className={clsx(
-          'animate-pulse rounded-[var(--radius)] bg-[var(--muted)]',
+          'animate-pulse rounded-[var(--radius)] bg-[var(--muted)] skeleton-glow',
           className,
         )}
         style={inlineStyle}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, forwardRef, HTMLAttributes, ReactNode } from 'react';
+import { motion } from 'framer-motion';
 
 export interface TooltipProps extends Omit<HTMLAttributes<HTMLDivElement>, 'content'> {
   content: ReactNode;
@@ -76,14 +77,17 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         {...props}
       >
         {children}
-        <div
+        <motion.div
           className={tooltipClasses}
           style={{ maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth }}
           role="tooltip"
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: show ? 1 : 0, y: show ? 0 : 4 }}
+          transition={{ duration: 0.2 }}
         >
           {content}
           {showArrow && <div className={arrowClasses} />}
-        </div>
+        </motion.div>
       </div>
     );
   }

--- a/src/examples/FuturisticDemo.stories.tsx
+++ b/src/examples/FuturisticDemo.stories.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useTheme } from '@/theme/ThemeContext';
+import Button from '@/components/Button/Button';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '@/components/Card/Card';
+import { Dialog, DialogTitle, DialogDescription, DialogFooter as ModalFooter } from '@/components/Dialog/Dialog';
+import { Loader } from '@/components/Loader';
+import { Alert } from '@/components/Alert';
+import { Stack } from '@/components/Stack';
+
+const meta: Meta = {
+  title: 'Examples/Futuristic Demo',
+  parameters: {
+    docs: {
+      description: {
+        component: 'Demonstrates a small UI flow with futuristic animations.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const FuturisticDemo: Story = {
+  render: () => <DemoFlow />,
+};
+
+const DemoFlow = () => {
+  useTheme();
+  const [open, setOpen] = React.useState(false);
+  const [loading, setLoading] = React.useState(false);
+  const [done, setDone] = React.useState(false);
+
+  const handleConfirm = () => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+      setDone(true);
+      setOpen(false);
+    }, 1000);
+  };
+
+  return (
+    <Stack gap="md">
+      <Card>
+        <CardHeader>
+          <CardTitle>Launch sequence</CardTitle>
+        </CardHeader>
+        <CardContent>Press the button to start the demo.</CardContent>
+        <CardFooter>
+          <Button onClick={() => setOpen(true)}>Open modal</Button>
+        </CardFooter>
+      </Card>
+
+      {done && (
+        <Alert variant="success" title="All good">
+          Demo complete!
+        </Alert>
+      )}
+
+      <Dialog isOpen={open} onClose={() => setOpen(false)}>
+        <DialogTitle>Proceed?</DialogTitle>
+        <DialogDescription>Confirm to view loader.</DialogDescription>
+        <ModalFooter>
+          <Button onClick={handleConfirm}>Confirm</Button>
+        </ModalFooter>
+      </Dialog>
+
+      {loading && <Loader center />}
+    </Stack>
+  );
+};


### PR DESCRIPTION
## Summary
- animate background for futuristic theme
- update Storybook decorator with futuristic visuals
- add new Futuristic Demo story
- add pulse effects to Button
- animate Card entry
- animate Dialog and Tooltip
- animate Loader rotation and Skeleton glow
- fade-in Alert messages

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6856cace2c548325afd5d52377518c3b