### PR TITLE
Add microinteraction helper and stories

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -28,3 +28,7 @@ export const Ghost: Story = {
 export const Disabled: Story = {
   args: { disabled: true },
 };
+
+export const Interactive: Story = {
+  args: { variant: 'primary', children: 'Hover me' },
+};

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion, type HTMLMotionProps } from 'framer-motion';
+import { useMicroInteraction } from '../../hooks';
 import clsx from 'clsx';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
@@ -22,6 +23,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
+    const micro = useMicroInteraction('button');
     const base = clsx(
       'inline-flex items-center justify-center rounded-[var(--radius)]',
       'border border-[var(--border)]',
@@ -48,16 +50,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         className={classes}
         aria-disabled={disabled}
-        whileHover={{
-          scale: disabled ? 1 : 1.05,
-          boxShadow: disabled ? 'none' : '0 0 0 4px var(--ring)',
-          filter: disabled ? 'none' : 'brightness(1.1)',
-        }}
-        whileFocus={{
-          scale: disabled ? 1 : 1.05,
-          boxShadow: disabled ? 'none' : '0 0 0 4px var(--ring)',
-        }}
-        transition={{ duration: 0.15 }}
+        whileHover={disabled ? undefined : micro.whileHover}
+        whileTap={disabled ? undefined : micro.whileTap}
+        whileFocus={disabled ? undefined : micro.whileFocus}
+        transition={micro.transition}
         disabled={disabled}
         {...props}
       >

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -29,3 +29,11 @@ export const WithClass: Story = {
     </Card>
   ),
 };
+
+export const AnimatedEntry: Story = {
+  render: (args) => (
+    <Card {...args}>
+      <CardContent>Animated card</CardContent>
+    </Card>
+  ),
+};

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { motion, type HTMLMotionProps } from 'framer-motion';
+import { useMicroInteraction } from '../../hooks';
 
 const Card = React.forwardRef<HTMLDivElement, HTMLMotionProps<'div'>>(
-  ({ className, ...props }, ref) => (
-    <motion.div
-      ref={ref}
-      className={`card ${className || ''}`}
-      initial={{ opacity: 0, y: 20, filter: 'blur(4px)' }}
-      animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-      transition={{ duration: 0.4 }}
-      {...props}
-    />
-  ),
+  ({ className, ...props }, ref) => {
+    const micro = useMicroInteraction('card');
+    return (
+      <motion.div
+        ref={ref}
+        className={`card ${className || ''}`}
+        {...micro}
+        {...props}
+      />
+    );
+  },
 );
 Card.displayName = 'Card';
 

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -80,3 +80,7 @@ export const WithRowActions: Story = {
     rowActions: (row: Row) => <Button size="sm">Edit {row.name}</Button>,
   },
 };
+
+export const RowHover: Story = {
+  args: { hover: true },
+};

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
+import { useMicroInteraction } from '../../hooks';
 import {
   ColumnDef,
   flexRender,
@@ -170,28 +171,35 @@ export function DataTable<TData extends { id: React.Key }>({
               </td>
             </tr>
           ) : (
-            rows.map((row) => (
-              <tr
-                key={row.id}
-                onClick={() => onRowClick?.(row.original)}
-                className={clsx(
-                  onRowClick && 'cursor-pointer',
-                  striped && 'even:bg-[var(--muted)]',
-                  hover && 'hover:bg-[var(--accent)]'
-                )}
-                aria-rowindex={row.index + 1}
-                aria-selected={row.getIsSelected() || undefined}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <td
-                    key={cell.id}
-                    className="border border-[var(--border)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-            ))
+            rows.map((row) => {
+              const micro = useMicroInteraction('table-row');
+              return (
+                <motion.tr
+                  key={row.id}
+                  onClick={() => onRowClick?.(row.original)}
+                  className={clsx(
+                    onRowClick && 'cursor-pointer',
+                    striped && 'even:bg-[var(--muted)]'
+                  )}
+                  aria-rowindex={row.index + 1}
+                  aria-selected={row.getIsSelected() || undefined}
+                  whileHover={hover ? micro.whileHover : undefined}
+                  whileTap={micro.whileTap}
+                  initial={micro.initial}
+                  animate={micro.animate}
+                  transition={micro.transition}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td
+                      key={cell.id}
+                      className="border border-[var(--border)] px-[var(--spacing-md)] py-[var(--spacing-sm)]"
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </motion.tr>
+              );
+            })
           )}
         </tbody>
       </table>

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import { Label } from '../Label';
+import { useMicroInteraction } from '../../hooks';
 
 export interface InputFieldProps
   extends Omit<
@@ -38,11 +40,12 @@ const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
       .filter(Boolean)
       .join(' ');
     const errorId = error ? `${id}-error` : undefined;
+    const micro = useMicroInteraction('input');
 
     return (
       <div className={wrapperClasses}>
         <Label htmlFor={id}>{label}</Label>
-        <input
+        <motion.input
           ref={ref}
           id={id}
           className={`input ${error ? 'input--error' : ''}`}
@@ -52,6 +55,7 @@ const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
           aria-invalid={Boolean(error)}
           aria-describedby={errorId}
           disabled={disabled}
+          {...micro}
           {...props}
         />
         {error && (

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import clsx from 'clsx';
+import { motion } from 'framer-motion';
 import { FormField, FormFieldProps } from '../FormField/FormField';
+import { useMicroInteraction } from '../../hooks';
 
 export interface SelectFieldProps
   extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'id'>,
@@ -9,10 +11,11 @@ export interface SelectFieldProps
 }
 
 export const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>(
-  (
+  ( 
     { id, label, description, error, required, wrapperClassName, className, children, ...props },
     ref,
   ) => {
+    const micro = useMicroInteraction('input');
     return (
       <FormField
         id={id}
@@ -22,17 +25,18 @@ export const SelectField = React.forwardRef<HTMLSelectElement, SelectFieldProps>
         required={required}
         className={wrapperClassName}
       >
-        <select
+        <motion.select
           ref={ref}
           className={clsx(
             'w-full rounded-[var(--radius)] border border-[var(--input)] bg-[var(--background)] p-2 text-sm',
             'focus:outline-none focus:border-[var(--ring)]',
             className,
           )}
+          {...micro}
           {...props}
         >
           {children}
-        </select>
+        </motion.select>
       </FormField>
     );
   },

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import clsx from 'clsx';
+import { motion } from 'framer-motion';
 import { FormField, FormFieldProps } from '../FormField/FormField';
+import { useMicroInteraction } from '../../hooks';
 
 export interface TextFieldProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'id'>,
@@ -26,6 +28,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     },
     ref,
   ) => {
+    const micro = useMicroInteraction('input');
     return (
       <FormField
         id={id}
@@ -35,7 +38,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         required={required}
         className={wrapperClassName}
       >
-        <input
+        <motion.input
           ref={ref}
           type={type}
           className={clsx(
@@ -43,6 +46,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             'focus:outline-none focus:border-[var(--ring)]',
             className,
           )}
+          {...micro}
           {...props}
         />
       </FormField>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './responsive';
 export * from './useNavigation';
+export * from './useMicroInteraction';

--- a/src/hooks/useMicroInteraction.tsx
+++ b/src/hooks/useMicroInteraction.tsx
@@ -1,0 +1,39 @@
+import { useReducedMotion } from 'framer-motion';
+
+export type MicroInteractionType =
+  | 'button'
+  | 'card'
+  | 'table-row'
+  | 'input'
+  | 'nav-item';
+
+export interface MicroInteractionProps {
+  whileHover?: object;
+  whileTap?: object;
+  whileFocus?: object;
+  initial?: object;
+  animate?: object;
+  transition?: object;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function useMicroInteraction(_type?: MicroInteractionType): MicroInteractionProps {
+  const reduce = useReducedMotion();
+
+  const hover = reduce ? {} : { scale: 1.02, filter: 'drop-shadow(0 0 4px var(--ring))' };
+  const tap = reduce ? {} : { scale: 0.98, boxShadow: 'inset 0 0 4px rgba(0,0,0,0.2)' };
+  const focus = reduce ? {} : { boxShadow: '0 0 0 2px var(--ring)', outlineOffset: '2px' };
+  const initial = reduce ? {} : { opacity: 0, y: 8 };
+  const animate = reduce ? {} : { opacity: 1, y: 0 };
+
+  return {
+    whileHover: hover,
+    whileTap: tap,
+    whileFocus: focus,
+    initial,
+    animate,
+    transition: { duration: 0.2, ease: 'easeInOut' },
+  };
+}
+
+export default useMicroInteraction;


### PR DESCRIPTION
## Summary
- add `useMicroInteraction` hook for common motion props
- refactor Button, Card, DataTable rows and form fields to use it
- showcase interactions via new stories

## Testing
- `npm run lint`
- `npm test`
- `npm run check:storybook`


------
https://chatgpt.com/codex/tasks/task_e_6856d3b635ec8325beecc520ccfb7d25